### PR TITLE
Added support for IsAssignableFrom on class/struct and interface types.

### DIFF
--- a/JSIL/AssemblyTranslator.cs
+++ b/JSIL/AssemblyTranslator.cs
@@ -498,7 +498,7 @@ namespace JSIL {
             output.Identifier("JSIL.MakeInterface", null);
             output.LPar();
             output.NewLine();
-
+            
             output.Value(Util.EscapeIdentifier(iface.FullName, EscapingMode.String));
             output.Comma();
 
@@ -551,6 +551,12 @@ namespace JSIL {
 
             output.NewLine();
             output.CloseBrace(false);
+            output.Comma();
+
+            output.OpenBracket();
+            foreach (var i in iface.Interfaces)
+                output.TypeReference(i);
+            output.CloseBracket();
 
             output.RPar();
             output.Semicolon();

--- a/Tests/SimpleTestCases/IsAssignableFrom.cs
+++ b/Tests/SimpleTestCases/IsAssignableFrom.cs
@@ -1,0 +1,32 @@
+﻿using System;
+
+class A { }
+class B { }
+class C : A { }
+class D : C { }
+class E : I { }
+class F : B, I { }
+class G : E { }
+struct H { }
+interface I { }
+struct J : I { }
+interface K : I { }
+class L : K { }
+
+public class Program
+{
+    public static void Main(string[] args)
+    {
+        var types = new[] { typeof(A), typeof(B), typeof(C), typeof(D), typeof(E), typeof(F), typeof(G), typeof(H), typeof(I), typeof(J), typeof(K), typeof(L) };
+
+        foreach (var t in types)
+        {
+            foreach (var t2 in types)
+            {
+                Console.WriteLine(t.FullName + " <- " + t2.FullName + "´: " + (t.IsAssignableFrom(t2) ? "True" : "False"));
+            }
+        }
+
+    }
+}
+

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -273,6 +273,7 @@
     <None Include="SimpleTestCases\ArrayOfStructsDefaultValues.cs" />
     <None Include="TestCases\CharConcat.cs" />
     <None Include="TestCases\GenericMethodAsGenericDelegate.cs" />
+    <None Include="SimpleTestCases\IsAssignableFrom.cs" />
     <Compile Include="TestCases\StaticInitializersInGenericTypesSettingStaticFields.cs" />
     <Compile Include="Util.cs" />
     <Compile Include="VerbatimTests.cs" />


### PR DESCRIPTION
Hi Kevin. I've added support for Type.IsAssignableFrom. Could you have a look at it? Please tell me if there are any problems or if there is anything you would have done differently. 

For this to work I've also added "inheritance" info to interfaces; so that when "interface J: I" gets translated, we keep the info about "I" being a parent of "J". This is not initialized right away though, so the evaluation of IsAssignableFrom is slower than it would need to be. But I think this is OK.
