### PR TITLE
Embarassingly little patch for helping spelunking with the compiler

### DIFF
--- a/Compiler/Program.cs
+++ b/Compiler/Program.cs
@@ -454,7 +454,6 @@ namespace JSIL.Compiler {
 
             if (buildGroups.Count < 1) {
                 Console.Error.WriteLine("// No assemblies specified to translate. Exiting.");
-                return;
             }
 
             foreach (var buildGroup in buildGroups) {
@@ -520,6 +519,11 @@ namespace JSIL.Compiler {
                         buildGroup.Profile.WriteOutputs(localVariables, outputs, outputDir, Path.GetFileName(filename) + ".");
                     }
                 }
+            }
+            
+            if (Environment.UserInteractive && Debugger.IsAttached) {
+                Console.Error.WriteLine("// Press the any key to continue.");
+                Console.ReadKey();
             }
         }
 


### PR DESCRIPTION
Small change to allow blocking on the output window when debugging, but leave well enough alone in production; this is helpful for examining outputs without having to continuously cut a command window or step-through
