### PR TITLE
Fix issue with casts from long/ulong to enum.

### DIFF
--- a/JSIL/Transforms/ExpandCastExpressions.cs
+++ b/JSIL/Transforms/ExpandCastExpressions.cs
@@ -75,6 +75,12 @@ namespace JSIL.Transforms {
                         newExpression = JSIL.ValueOfNullable(
                             ce.Expression
                         );
+                    } else if (
+                        ce.Expression is JSCastExpression &&
+                        (((JSCastExpression)ce.Expression).Expression.GetActualType(TypeSystem).MetadataType == MetadataType.Int64 ||
+                        ((JSCastExpression)ce.Expression).Expression.GetActualType(TypeSystem).MetadataType == MetadataType.UInt64)
+                    ) {
+                        newExpression = ce.Expression;
                     } else {
                         newExpression = JSInvocationExpression.InvokeMethod(
                             JS.valueOf(targetType), ce.Expression, null, true

--- a/Tests/Int64TestCases/Int64CastToEnum.cs
+++ b/Tests/Int64TestCases/Int64CastToEnum.cs
@@ -1,0 +1,15 @@
+﻿
+using System;
+enum E { a, b }
+
+public static class Program
+{
+    public static ulong GetULong() { return 0UL; }
+    public static long GetLong() { return 0L; }
+
+    public static void Main(string[] args)
+    {
+        Console.WriteLine((E)GetULong());
+        Console.WriteLine((E)GetLong());
+    }
+}

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -313,6 +313,7 @@
     <None Include="SimpleTestCases\AsWithGenericParameter.cs" />
     <None Include="SimpleTestCases\ListRemoveRange.cs" />
     <None Include="SimpleTestCases\ListBinarySearch.cs" />
+    <None Include="Int64TestCases\Int64CastToEnum.cs" />
     <Compile Include="XMLTests.cs" />
     <Compile Include="DependencyTests.cs" />
     <None Include="TestCases\GenericParameterNameShadowing.cs" />


### PR DESCRIPTION
I don't really understand why the expression look like it does, but somehow a long -> enum cast becomes long -> enum -> int, which is one cast too much.. In this fix I strip the int cast if it shows up.
