### PR TITLE
Stub Stream.CanRead

### DIFF
--- a/Libraries/JSIL.IO.js
+++ b/Libraries/JSIL.IO.js
@@ -544,6 +544,13 @@ var $bytestream = function ($) {
     }
   );
   
+  $.Method({Static:false, Public:true }, "get_CanRead", 
+    (new JSIL.MethodSignature($.Boolean, [], [])), 
+    function get_CanRead () {
+      return true;
+    }
+  );
+  
   $.Method({Static:false, Public:true }, "Seek", 
     (new JSIL.MethodSignature($.Int64, [$.Int64, $jsilcore.TypeRef("System.IO.SeekOrigin")], [])), 
     function Seek (offset, origin) {


### PR DESCRIPTION
MSDN: http://msdn.microsoft.com/en-us/library/system.io.stream.canread.aspx

This property is supposed to return true if the stream supports reading and is open.

Since JSIL currently has no write-only streams, and calling Close() does not prevent further Read()'s, always returning true should not cause any problems.
