### PR TITLE
Interfaces should have no base type

### DIFF
--- a/Libraries/JSIL.Core.js
+++ b/Libraries/JSIL.Core.js
@@ -4832,6 +4832,7 @@ JSIL.MakeInterface = function (fullName, isPublic, genericArguments, initializer
     publicInterface.__Type__ = typeObject;
 
     typeObject.__PublicInterface__ = publicInterface;
+    typeObject.__BaseType__ = null;
     typeObject.__CallStack__ = callStack;
     JSIL.SetTypeId(typeObject, publicInterface, JSIL.AssignTypeId(assembly, fullName));
 

--- a/Tests/SimpleTestCases/InterfaceBaseType.cs
+++ b/Tests/SimpleTestCases/InterfaceBaseType.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+interface I {
+}
+
+class Program {
+    public static void Main () {
+        Console.WriteLine(typeof(I).BaseType);
+        Console.WriteLine(typeof(I).BaseType == null ? "true" : "false");
+  }
+}

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -188,6 +188,7 @@
     <None Include="SimpleTestCases\EnumBaseType.cs" />
     <None Include="SimpleTestCases\EnumerableSum.cs" />
     <None Include="SimpleTestCases\Issue213.cs" />
+    <None Include="SimpleTestCases\InterfaceBaseType.cs" />
     <None Include="SimpleTestCases\ArrayCopyEnum.cs" />
     <Compile Include="TypeInformationTests.cs" />
     <None Include="TestCases\LongArithmetic.cs" />


### PR DESCRIPTION
Right now interfaces have System.Type as the base type, just like enums had before you fixed it in 911108608362a21eacb2958e089eb84c78f49c2b.
