### PR TITLE
Implement calling methods of System.Convert with objects

### DIFF
--- a/Tests/SimpleTestCases/ConvertObject.cs
+++ b/Tests/SimpleTestCases/ConvertObject.cs
@@ -1,0 +1,107 @@
+﻿using System;
+
+class Stringifiable {
+    public override string ToString () {
+        return "It works!";
+    }
+}
+
+class Convertible : IConvertible {
+    public TypeCode GetTypeCode () {
+        throw new NotImplementedException(); // not needed in this test case
+    }
+    
+    public DateTime ToDateTime( IFormatProvider provider) {
+        throw new NotImplementedException(); // DateTime is not implemented by JSIL as of writing of this test case
+    }
+    
+    public decimal ToDecimal (IFormatProvider provider) {
+        throw new NotImplementedException(); // Decimal is not completely supported by JSIL as of writing of this test case
+    }
+    
+    public object ToType (Type conversionType, IFormatProvider provider) {
+        if (conversionType == typeof(Stringifiable))
+            return new Stringifiable();
+        
+        throw new NotImplementedException();
+    }
+    
+    public bool ToBoolean (IFormatProvider provider) {
+        return true;
+    }
+
+    public char ToChar (IFormatProvider provider) {
+        return 'a';
+    }
+    
+    public string ToString (IFormatProvider provider) {
+       return "Hello!";
+    }
+    
+    public byte ToByte (IFormatProvider provider) {
+        return 1;
+    }
+
+    public sbyte ToSByte (IFormatProvider provider) {
+       return -1;
+    }
+
+    public ushort ToUInt16 (IFormatProvider provider) {
+        return 2;
+    }
+    
+    public short ToInt16 (IFormatProvider provider) {
+        return -2;
+    }
+    
+    public uint ToUInt32 (IFormatProvider provider) {
+        return 3;
+    }
+    
+    public int ToInt32 (IFormatProvider provider) {
+        return -3;
+    }
+
+    public ulong ToUInt64 (IFormatProvider provider) {
+        return 4;
+    }
+    
+    public long ToInt64 (IFormatProvider provider) {
+        return -4;
+    }
+  
+    public float ToSingle (IFormatProvider provider) {
+        return 5.55f;
+    }
+    
+    public double ToDouble (IFormatProvider provider) {
+        return 6.66;
+    }
+}
+
+class Program {
+    private static void TestConversion (object o) {
+        Console.WriteLine(Convert.ToBoolean(o) ? "true" : "false");
+        Console.WriteLine((int) Convert.ToChar(o));
+        Console.WriteLine(Convert.ToString(o));
+        Console.WriteLine(Convert.ToByte(o));
+        Console.WriteLine(Convert.ToSByte(o));
+        Console.WriteLine(Convert.ToUInt16(o));
+        Console.WriteLine(Convert.ToInt16(o));
+        Console.WriteLine(Convert.ToUInt32(o));
+        Console.WriteLine(Convert.ToInt32(o));
+        Console.WriteLine(Convert.ToUInt64(o));
+        Console.WriteLine(Convert.ToInt64(o));
+        Console.WriteLine(Convert.ToSingle(o));
+        Console.WriteLine(Convert.ToDouble(o));
+        Console.WriteLine(Convert.ChangeType(o, typeof(Stringifiable)) ?? "null");
+    }
+    
+    public static void Main () {
+        Console.WriteLine(Convert.ToString(new object()));
+        Console.WriteLine(Convert.ToString(new Stringifiable()));
+
+        TestConversion(null);
+        TestConversion(new Convertible());
+    }
+}

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -184,6 +184,7 @@
     <None Include="InterfaceTestCases\OverloadedGenericMethodInsideNonGenericInterface.cs" />
     <None Include="SpecialTestCases\AddNewField.cs" />
     <None Include="SimpleTestCases\NullableStructRef.cs" />
+    <None Include="SimpleTestCases\ConvertObject.cs" />
     <None Include="PerformanceTestCases\RectangleIntersects.cs" />
     <None Include="SimpleTestCases\EnumBaseType.cs" />
     <None Include="SimpleTestCases\EnumerableSum.cs" />


### PR DESCRIPTION
Some minor improvements to the System.Convert class:
- Convert.ChangeType now correctly checks if the object implements IConvertible
- Convert.ToString(obj) calls obj.toString()
- Convert.To____(null) returns 0, false or "" depending on the method
- Convert.To____(obj) checks if the object implements IConvertible, is so, calls it
- Convert.ToChar({int, uint, long, ulong})

It should also support enums once #211 is resolved.
