### PR TITLE
Implement string.GetHashCode

### DIFF
--- a/Libraries/JSIL.Bootstrap.js
+++ b/Libraries/JSIL.Bootstrap.js
@@ -16,6 +16,16 @@ String.prototype.Object_Equals = function (rhs) {
   return this === rhs;
 };
 
+String.prototype.GetHashCode = function () {
+  var h = 0;
+  
+  for (var i = 0; i < this.length; i++) {
+    h = ((h << 5) - h + this.charCodeAt(i)) & ~0;
+  }
+ 
+  return h;
+};
+
 
 // HACK: Nasty compatibility shim for JS Error <-> C# Exception
 Error.prototype.get_Message = function () {

--- a/Tests/SimpleTestCases/StringGetHashCode.cs
+++ b/Tests/SimpleTestCases/StringGetHashCode.cs
@@ -1,0 +1,40 @@
+﻿using System;
+
+using JSIL;
+
+class Program {
+    class TestCase {
+        public TestCase (string text, int expectedHashCode) {
+            Text = text;
+            ExpectedHashCode = expectedHashCode;
+        }
+        
+        public string Text { get; private  set; }
+        public int ExpectedHashCode { get; private set; }
+    }
+    
+    public static void Main () {
+        if (!Builtins.IsJavascript)
+            return; // output cannnot be compared as .NET uses a different hashing algorithm
+        
+         var testCases = new[] {
+            new TestCase("", 0),
+            new TestCase("a", 97),
+            new TestCase("ą", 261),
+            new TestCase("ы", 1099),
+            new TestCase("ab", 3105),
+            new TestCase("abcdefg", -1206291356),
+            new TestCase("abcdefgh", 1259673732),
+            new TestCase("JSIL is a compiler that transforms .NET applications and libraries from their native executable format - CIL bytecode - into standards-compliant, cross-browser JavaScript.", 1397971535)
+        };
+        
+        foreach (var testCase in testCases) {
+            var hashCode = testCase.Text.GetHashCode();
+            
+            if (hashCode == testCase.ExpectedHashCode)
+                continue;
+            
+            throw new Exception(string.Format("\"{0}\": expected hash code {1}, was {2}", testCase.Text, testCase.ExpectedHashCode, hashCode));
+        }
+    }
+}

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -191,6 +191,7 @@
     <None Include="SimpleTestCases\Issue213.cs" />
     <None Include="SimpleTestCases\InterfaceBaseType.cs" />
     <None Include="SimpleTestCases\ArrayCopyEnum.cs" />
+    <None Include="SimpleTestCases\StringGetHashCode.cs" />
     <Compile Include="TypeInformationTests.cs" />
     <None Include="TestCases\LongArithmetic.cs" />
     <None Include="InterfaceTestCases\NestedInterfaces.cs" />


### PR DESCRIPTION
Here's an implementation of string.GetHashCode using Mono's algorithm ( https://github.com/mono/mono/blob/master/mcs/class/corlib/System/String.cs#L2653 ). The test case compares hashes with those computed on Mono.
