### PR TITLE
Implement FileStream.Name

### DIFF
--- a/Libraries/JSIL.IO.js
+++ b/Libraries/JSIL.IO.js
@@ -698,6 +698,13 @@ JSIL.ImplementExternals("System.IO.FileStream", function ($) {
 
     return uri;
   });
+  
+  $.Method({Static:false, Public:true }, "get_Name", 
+    (new JSIL.MethodSignature($.String, [], [])), 
+    function get_Name () {
+      return this._fileName;
+    }
+  );
 });
 
 JSIL.ImplementExternals(


### PR DESCRIPTION
MSDN: http://msdn.microsoft.com/en-us/library/system.io.filestream.name.aspx

This property returns the full path of the file that the FileStream opened. There is already a _fileName field containing the full path that is set when the constructor calls $fromVirtualFile, so simply returning it should be sufficient.
