### PR TITLE
Implement char.IsLetter, char.IsLetterOrDigit, char.IsSurrogate for non-Unicode characters; fix char.IsWhiteSpace

### DIFF
--- a/Libraries/JSIL.Bootstrap.Text.js
+++ b/Libraries/JSIL.Bootstrap.Text.js
@@ -2019,16 +2019,42 @@ JSIL.ImplementExternals("System.Char", function ($) {
     }
   );
 
+  $.Method({Static:true , Public:true }, "IsLetter", 
+    new JSIL.MethodSignature($.Boolean, [$.Char], []), 
+    function IsLetter (c) {
+      // FIXME: Unicode
+      var charCode = c.charCodeAt(0);
+      return (
+        ((charCode >= 65) && (charCode <= 90)) ||
+        ((charCode >= 97) && (charCode <= 122)));
+    }
+  );
+
+  $.Method({Static:true , Public:true }, "IsLetterOrDigit", 
+    new JSIL.MethodSignature($.Boolean, [$.Char], []), 
+    function IsLetterOrDigit (c) {
+      return $jsilcore.System.Char.IsLetter(c) || $jsilcore.System.Char.IsDigit(c);
+    }
+  );
+
+  $.Method({Static:true , Public:true }, "IsSurrogate", 
+    new JSIL.MethodSignature($.Boolean, [$.Char], []), 
+    function IsSurrogate (c) {
+      var charCode = c.charCodeAt(0);
+      return (charCode >= 0xD800) && (charCode <= 0xDFFF);
+    }
+  );
+
   $.Method({Static:true , Public:true }, "IsWhiteSpace", 
     new JSIL.MethodSignature($.Boolean, [$.Char], []), 
     function IsWhiteSpace (c) {
       // FIXME: Unicode
       var charCode = c.charCodeAt(0);
-      return 
+      return (
         ((charCode >= 0x09) && (charCode <= 0x13)) || 
         (charCode === 0x20) ||
         (charCode === 0xA0) || 
-        (charCode === 0x85);
+        (charCode === 0x85));
     }
   );
 });

--- a/Tests/SimpleTestCases/CharIs.cs
+++ b/Tests/SimpleTestCases/CharIs.cs
@@ -1,0 +1,36 @@
+﻿using System;
+
+class Program {
+    static void Categorize (char c) {
+        Console.WriteLine((int) c);
+        
+        if (char.IsControl(c))
+            Console.WriteLine("IsControl");
+        
+        if (char.IsDigit(c))
+            Console.WriteLine("IsDigit");
+        
+        if (char.IsLetter(c))
+            Console.WriteLine("IsLetter");
+        
+        if (char.IsLetterOrDigit(c))
+            Console.WriteLine("IsLetterOrDigit");
+        
+        if( char.IsSurrogate(c))
+            Console.WriteLine("IsSurrogate");
+        
+        if (char.IsWhiteSpace(c))
+            Console.WriteLine("IsWhiteSpace");
+        
+        Console.WriteLine();
+    }
+    
+    public static void Main () {
+        Categorize(' ');
+        Categorize('4');
+        Categorize('J');
+        Categorize('s');
+        Categorize((char) 0x0D);
+        Categorize((char) 0xD801);
+    }
+}

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -213,6 +213,7 @@
     <None Include="SimpleTestCases\CharArithmetic.cs" />
     <None Include="SimpleTestCases\StringFormatCurlies.cs" />
     <None Include="SpecialTestCases\PointerSignature.cs" />
+    <None Include="SimpleTestCases\CharIs.cs" />
     <Compile Include="TypeInformationTests.cs" />
     <None Include="TestCases\LongArithmetic.cs" />
     <None Include="InterfaceTestCases\NestedInterfaces.cs" />


### PR DESCRIPTION
Since it hasn't been decided if JSIL should include the huge unicode category table ( #225), here's an ANSI-only implementation of char.IsLetter.

Also included is an implementation of IsLetterOrDigit (IsLetter || IsDigit), IsSurrogate (Wikipedia says it's a single range), and a fix for IsWhiteSpace (return statement body was on a separate line, therefore it returned undefined).
