### PR TITLE
Implement FieldInfo.GetValue

### DIFF
--- a/Libraries/JSIL.Core.Reflection.js
+++ b/Libraries/JSIL.Core.Reflection.js
@@ -724,6 +724,25 @@ JSIL.ImplementExternals(
         return this._data.constant;
       }
     );
+    
+    $.Method({Static:false, Public:true, Virtual:true }, "GetValue",
+      (new JSIL.MethodSignature($.Object, [$.Object], [])),
+      function GetValue (obj) {
+        if (this.IsStatic) {
+          return this.DeclaringType.__PublicInterface__[this._descriptor.Name];
+        }
+
+        if (obj === null) {
+          throw new System.Exception("Non-static field requires a target.");
+        }
+
+        if (!this.DeclaringType.IsAssignableFrom(obj.__ThisType__)) {
+          throw new System.Exception("Field is not defined on the target object.");
+        }
+
+        return obj[this._descriptor.Name];
+      }
+    );
   }
 );
 

--- a/Tests/ReflectionTestCases/FieldGetValue.cs
+++ b/Tests/ReflectionTestCases/FieldGetValue.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Reflection;
+
+class Program {
+    static void PrintFieldValues (FieldInfo[] fields, object obj) {
+        foreach (FieldInfo field in fields) {
+            // not printing field names because automatic property backing field names differ between .NET and JSIL
+            Console.WriteLine(field.GetValue(obj)); 
+        }
+    }
+    
+    static void AssertThrows (Action action) {
+        try {
+            action();
+            Console.WriteLine("Not OK: exception was not thrown");
+        } catch (Exception) {
+            Console.WriteLine("OK: exception was thrown");
+        }
+    }
+    
+    public static void Main () {
+        BindingFlags all = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static;
+        BindingFlags allStatic = all ^ BindingFlags.Instance;
+        
+        PrintFieldValues(typeof(MyStruct).GetFields(all), new MyStruct(1, 2, "3"));
+        PrintFieldValues(typeof(MyEnum).GetFields(allStatic), null);
+        PrintFieldValues(typeof(MyClass).GetFields(all), new MyClass());
+        PrintFieldValues(typeof(MyClass).GetFields(all), new MySubclass());
+        PrintFieldValues(typeof(MyClass).GetFields(allStatic), null);
+        
+        AssertThrows(() => PrintFieldValues(typeof(MyClass).GetFields(all), null));
+        AssertThrows(() => PrintFieldValues(typeof(MyStruct).GetFields(all), new MyClass()));
+    }
+}
+
+struct MyStruct {
+    public int Field1;
+    public long Field2;
+    public string Field3;
+    
+    public MyStruct (byte field1, int field2, string field3) {
+        Field1 = field1;
+        Field2 = field2;
+        Field3 = field3;
+    }
+}
+
+enum MyEnum {
+    A = 3,
+    B = 5,
+    C = 7
+}
+
+class MyClass {
+    public int Field1 = 4;
+    public long Field2 = 8;
+    public string Field3 = "15";
+    
+    public static uint StaticField1 = 16;
+    public static ulong StaticField2 = 23;
+    
+    public static string AutomaticProperty1 { get; set; }
+    
+    static MyClass() {
+        AutomaticProperty1 = "42";
+    }
+}
+
+class MySubclass : MyClass {
+}

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -213,6 +213,7 @@
     <None Include="SimpleTestCases\CharArithmetic.cs" />
     <None Include="SimpleTestCases\StringFormatCurlies.cs" />
     <None Include="SpecialTestCases\PointerSignature.cs" />
+    <None Include="ReflectionTestCases\FieldGetValue.cs" />
     <Compile Include="TypeInformationTests.cs" />
     <None Include="TestCases\LongArithmetic.cs" />
     <None Include="InterfaceTestCases\NestedInterfaces.cs" />


### PR DESCRIPTION
Is it OK to use [this._descriptor.Name]? I can't think of a test case where EscapedName or MangledName should be used instead.
