### PR TITLE
Fixed an issue where non-CLR assemblies (such as "Setup.exe" files) were not ignored. ...

### DIFF
--- a/Compiler/Program.cs
+++ b/Compiler/Program.cs
@@ -88,7 +88,7 @@ namespace JSIL.Compiler {
             {
                 return AssemblyDefinition.ReadAssembly(fileName);
             }
-            catch(Exception ex)
+            catch(BadImageFormatException ex)
             {
                 Console.Error.WriteLine("// Invalid .NET Assembly: \"" + fileName + "\".  It will not be loaded.");
                 Console.Error.WriteLine("//     Reason: " + (ex.Message ?? "").Trim().Replace(Environment.NewLine, Environment.NewLine + "// "));


### PR DESCRIPTION
... This was causing ILSpy exceptions, and aborting the entire solution compliation.  This happens even when patterns matching the outputs were added to the "Assemblies": { "Ignored:" [] } array in the .sln.jsilconfig file.

To test, create a solution that has a WiX Bootstrapper in it that build successfully at compile time and outputs a non-CLR .exe file (i.e. the WiX "Burn" Bootstrapper fulfills this requirement).  Run JSILc.exe against the solution.  It will throw an exception at the line containing "AssemblyDefinition.ReadAssembly(fn)" shown below.  To fix, I wrapped the call in a try/catch in a static method that will return null -- and further, I remove items where Assembly = null from the array using a .Where(...) condition before the IEnumerable is converted to an array.

[ I have an example solution on the web at: http://brainslugs83.azurewebsites.net/LD27-Downloads/ClickClickBoom-Source-2013-08-30.zip ]
