### PR TITLE
Fixes an "AmbiguousMatchException" where the extra matches really aren't all that Ambiguous...

### DIFF
--- a/Compiler/Profiles/XNACommon.cs
+++ b/Compiler/Profiles/XNACommon.cs
@@ -951,7 +951,7 @@ public static class Common {
                         matchingBuiltPaths = (from mbp in matchingBuiltPaths
                                               where 
                                                   File.Exists(mbp) &&
-                                                  System.IO.Path.GetDirectoryName(mbp) != System.IO.Path.GetDirectoryName(itemOutputDirectory + "\\")
+                                                  System.IO.Path.GetDirectoryName(mbp) != System.IO.Path.GetDirectoryName(itemOutputDirectory + Path.DirectorySeparatorChar)
                                               select mbp).ToArray();
 
                         // Throw the exception if the match is still ambiguous.


### PR DESCRIPTION
... (i.e. they don't exist and/or they're located in the itemOutputDirectory).

This can happen if the solution you're decompiling also contains a web project, and the .sln.jsilconfig specifies that the OutputDirectory should be to a location inside that web project, and that web project has those files added to it as "Content".

[ An example of a solution which causes this issue can be found at: http://brainslugs83.azurewebsites.net/LD27-Downloads/ClickClickBoom-Source-2013-08-30.zip ]
