### PR TITLE
Always resolve full path when generate resources. 

### DIFF
--- a/Compiler/Profiles/Base.cs
+++ b/Compiler/Profiles/Base.cs
@@ -55,7 +55,7 @@ namespace JSIL.Compiler.Profiles {
         protected void PostProcessAllTranslatedAssemblies(
             Configuration configuration, string assemblyPath, TranslationResult result)
         {
-            string basePath = Path.GetDirectoryName(assemblyPath);
+            string basePath = Path.GetDirectoryName(Path.GetFullPath(assemblyPath));
             List<string> assemblyPaths = new List<string>();
 
             foreach (var item in result.Assemblies)

--- a/Compiler/Profiles/ResourceConverter.cs
+++ b/Compiler/Profiles/ResourceConverter.cs
@@ -11,7 +11,9 @@ using JSIL.Compiler;
 
 namespace JSIL.Utilities {
     public static class ResourceConverter {
-        public static void ConvertResources (Configuration configuration, string assemblyPath, TranslationResult result) {
+        public static void ConvertResources (Configuration configuration, string assemblyPath, TranslationResult result)
+        {
+            assemblyPath = Path.GetFullPath(assemblyPath);
             ConvertEmbeddedResources(configuration, assemblyPath, result);
             ConvertSatelliteResources(configuration, assemblyPath, result);
         }


### PR DESCRIPTION
Fix #387.
