### PR TITLE
Workaround Mono bug in AppDomain creation

### DIFF
--- a/Compiler/Profiles/ResourceConverter.cs
+++ b/Compiler/Profiles/ResourceConverter.cs
@@ -123,13 +123,21 @@ namespace JSIL.Utilities {
                 CachePath = currentSetup.CachePath,
                 ConfigurationFile = currentSetup.ConfigurationFile,
                 DisallowCodeDownload = true,
-                DynamicBase = currentSetup.DynamicBase,
                 PrivateBinPath = currentSetup.PrivateBinPath,
                 PrivateBinPathProbe = currentSetup.PrivateBinPathProbe,
                 ShadowCopyDirectories = currentSetup.ShadowCopyDirectories,
                 ShadowCopyFiles = currentSetup.ShadowCopyFiles,
                 LoaderOptimization = LoaderOptimization.MultiDomain
             };
+
+            try
+            {
+                domainSetup.DynamicBase = currentSetup.DynamicBase;
+            }
+            catch (System.MemberAccessException)
+            {
+                // Mono bugs! Yay!
+            }
 
             Domain = AppDomain.CreateDomain(name, null, domainSetup);
         }


### PR DESCRIPTION
Mono doesn't seem to guarantee order of property setting, and DynamicBase can't be set until ApplicationName is set.  Originally I tried just setting DynamicBase after the AppDomainSetup was created but it still seemed to fail (perhaps because ApplicationName is empty or null?)

In either case, everything still seems to work with this change, it just doesn't crash under Mono any more.
