### PR TITLE
Repo compatibility with hg-git and TeamCity

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,12 @@
+[submodule "Examples/Tetris"]
+	path = Examples/Tetris
+	url = https://github.com/ttocs7/tetris.git
+[submodule "Examples/Mannux-xna"]
+	path = Examples/Mannux-xna
+	url = git@github.com:kevingadd/XnaMannux.git
+[submodule "Examples/PlatformerStarterKit"]
+	path = Examples/PlatformerStarterKit
+	url = git@github.com:kevingadd/PlatformerStarterKit.git
 [submodule "Upstream/Gamepad.js"]
 	path = Upstream/Gamepad.js
 	url = https://github.com/kevingadd/gamepad.js.git


### PR DESCRIPTION
In this commit I've removed submodules from .gitmodules that are no more in use. It helps to work with repository using Mercurial through its hg-git plugin (really it is workaround of hg-git plugin problem).
Also I've changed URL of ILSpy upstream to canonical form, otherwise TeamCity has problems with fetching repository.
