### PR TITLE
Dictionary implements IDictionary and IDictionary<TKey, TValue>

### DIFF
--- a/Libraries/JSIL.Bootstrap.js
+++ b/Libraries/JSIL.Bootstrap.js
@@ -2416,7 +2416,7 @@ JSIL.ImplementExternals("System.Collections.Generic.Dictionary`2+KeyCollection",
   );
     
   $.Method({ Static: false, Public: true }, "GetEnumerator",
-    new JSIL.MethodSignature($jsilcore.TypeRef("System.Collections.Generic.IEnumerator`1", [new JSIL.GenericParameter("TValue", "System.Collections.Generic.Dictionary`2+ValueCollection")]), [], []),
+    new JSIL.MethodSignature($jsilcore.TypeRef("System.Collections.Generic.IEnumerator`1", [new JSIL.GenericParameter("TKey", "System.Collections.Generic.Dictionary`2+KeyCollection")]), [], []),
     function GetEnumerator() {
         return JSIL.CreateInstanceOfType(this.dictionary.tKeyEnumerator, [this.dictionary]);
     }
@@ -2508,7 +2508,8 @@ JSIL.ImplementExternals("System.Collections.Generic.Dictionary`2+KeyCollection+E
     function get_Current () {
       return this.kvpEnumerator.get_Current().key;
     }
-  );
+  )
+      .Overrides("System.Collections.Generic.IEnumerator`1", "get_Current");
 
   $.Method({Static:false, Public:true , Virtual:true }, "MoveNext", 
     new JSIL.MethodSignature($.Boolean, [], []), 
@@ -2523,7 +2524,7 @@ JSIL.ImplementExternals("System.Collections.Generic.Dictionary`2+KeyCollection+E
       return this.kvpEnumerator.get_Current().key;
     }
   )
-    .Overrides(2, "get_Current");
+    .Overrides("System.Collections.IEnumerator", "get_Current");
 
   $.Method({Static:false, Public:false, Virtual:true }, "System.Collections.IEnumerator.Reset", 
     new JSIL.MethodSignature(null, [], []), 
@@ -2531,7 +2532,7 @@ JSIL.ImplementExternals("System.Collections.Generic.Dictionary`2+KeyCollection+E
       this.kvpEnumerator = this.dictionary.GetEnumerator();
     }
   )
-    .Overrides(2, "Reset");
+    .Overrides("System.Collections.IEnumerator", "Reset");
 });
 
 JSIL.ImplementExternals("System.Collections.Generic.Dictionary`2+ValueCollection+Enumerator", function ($interfaceBuilder) {
@@ -2569,7 +2570,8 @@ JSIL.ImplementExternals("System.Collections.Generic.Dictionary`2+ValueCollection
     function get_Current () {
       return this.kvpEnumerator.get_Current().value;
     }
-  );
+  )
+      .Overrides("System.Collections.Generic.IEnumerator`1", "get_Current");
 
   $.Method({Static:false, Public:true , Virtual:true }, "MoveNext", 
     new JSIL.MethodSignature($.Boolean, [], []), 
@@ -2584,7 +2586,7 @@ JSIL.ImplementExternals("System.Collections.Generic.Dictionary`2+ValueCollection
       return this.kvpEnumerator.get_Current().value;
     }
   )
-    .Overrides(2, "get_Current");
+    .Overrides("System.Collections.IEnumerator", "get_Current");
 
   $.Method({Static:false, Public:false, Virtual:true }, "System.Collections.IEnumerator.Reset", 
     new JSIL.MethodSignature(null, [], []), 
@@ -2592,7 +2594,7 @@ JSIL.ImplementExternals("System.Collections.Generic.Dictionary`2+ValueCollection
       this.kvpEnumerator = this.dictionary.GetEnumerator();
     }
   )
-    .Overrides(2, "Reset");
+    .Overrides("System.Collections.IEnumerator", "Reset");
 });
 
 JSIL.MakeStruct("System.ValueType", "System.Collections.Generic.KeyValuePair`2", true, ["TKey", "TValue"], function ($) {
@@ -2677,6 +2679,12 @@ JSIL.MakeType({
     GenericParameters: ["TKey", "TValue"], 
     MaximumConstructorArguments: 1, 
   }, function ($) {
+      $.ImplementInterfaces(
+          $jsilcore.TypeRef("System.Collections.Generic.ICollection`1", [new JSIL.GenericParameter("TKey", "System.Collections.Generic.Dictionary`2+KeyCollection")]),
+          $jsilcore.TypeRef("System.Collections.ICollection"),
+          $jsilcore.TypeRef("System.Collections.Generic.IEnumerable`1", [new JSIL.GenericParameter("TKey", "System.Collections.Generic.Dictionary`2+KeyCollection")]),
+          $jsilcore.TypeRef("System.Collections.IEnumerable")
+      );
 });
 
 JSIL.MakeType({
@@ -2687,6 +2695,12 @@ JSIL.MakeType({
     GenericParameters: ["TKey", "TValue"], 
     MaximumConstructorArguments: 1, 
   }, function ($) {
+      $.ImplementInterfaces(
+          $jsilcore.TypeRef("System.Collections.Generic.ICollection`1", [new JSIL.GenericParameter("TValue", "System.Collections.Generic.Dictionary`2+ValueCollection")]),
+          $jsilcore.TypeRef("System.Collections.ICollection"),
+          $jsilcore.TypeRef("System.Collections.Generic.IEnumerable`1", [new JSIL.GenericParameter("TValue", "System.Collections.Generic.Dictionary`2+ValueCollection")]),
+          $jsilcore.TypeRef("System.Collections.IEnumerable")
+      );
 });
 
 JSIL.MakeType({
@@ -2697,6 +2711,11 @@ JSIL.MakeType({
     GenericParameters: ["TKey", "TValue"], 
     MaximumConstructorArguments: 1, 
   }, function ($) {
+      $.ImplementInterfaces(
+          $jsilcore.TypeRef("System.Collections.Generic.IEnumerator`1", [new JSIL.GenericParameter("TKey", "System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator")]),
+          $jsilcore.TypeRef("System.IDisposable"),
+          $jsilcore.TypeRef("System.Collections.IEnumerator")
+      );
 });
 
 JSIL.MakeType({
@@ -2707,6 +2726,11 @@ JSIL.MakeType({
     GenericParameters: ["TKey", "TValue"], 
     MaximumConstructorArguments: 1, 
   }, function ($) {
+      $.ImplementInterfaces(
+          $jsilcore.TypeRef("System.Collections.Generic.IEnumerator`1", [new JSIL.GenericParameter("TValue", "System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator")]),
+          $jsilcore.TypeRef("System.IDisposable"),
+          $jsilcore.TypeRef("System.Collections.IEnumerator")
+      );
 });
 
 JSIL.ImplementExternals("System.Collections.Generic.Dictionary`2+Enumerator", function ($interfaceBuilder) {

--- a/Tests/ComparisonTests.cs
+++ b/Tests/ComparisonTests.cs
@@ -271,6 +271,7 @@ namespace JSIL.Tests {
                     @"TestCases\DictionaryKeyValuePairs.cs",
                     @"TestCases\DictionaryValueCollectionCount.cs",
                     @"TestCases\DictionaryKeysAndValues.cs",
+                    @"TestCases\DictionaryInterfaces.cs",
                 }, MakeDefaultProvider(), new AssemblyCache()
             );
         }

--- a/Tests/TestCases/DictionaryInterfaces.cs
+++ b/Tests/TestCases/DictionaryInterfaces.cs
@@ -1,0 +1,113 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections;
+
+
+public static class Program {
+    public static void Main (string[] args)
+    {
+        var genericIDictionary = GetFilledGenericIDictionary();
+        Console.WriteLine(genericIDictionary.Count);
+        foreach (var pair in genericIDictionary)
+        {
+            Console.WriteLine(pair.Key);
+            Console.WriteLine(pair.Value);
+        }
+        foreach (var value in genericIDictionary.Values)
+        {
+            Console.WriteLine(value);
+        }
+        foreach (var value in genericIDictionary.Keys)
+        {
+            Console.WriteLine(value);
+        }
+
+        var iDictionary = GetFilledIDictionary();
+        Console.WriteLine(iDictionary.Count);
+        foreach (var pair in genericIDictionary)
+        {
+            Console.WriteLine(pair.Key);
+            Console.WriteLine(pair.Value);
+        } 
+        foreach (var value in iDictionary.Values)
+        {
+            Console.WriteLine(value);
+        }
+        foreach (var value in iDictionary.Keys)
+        {
+            Console.WriteLine(value);
+        }
+
+        var genericICollection = GetFilledGenericICollection();
+        Console.WriteLine(genericICollection.Count);
+        foreach (var pair in genericICollection)
+        {
+            Console.WriteLine(pair.Key);
+            Console.WriteLine(pair.Value);
+        }
+
+        var iCollection = GetFilledICollection();
+        Console.WriteLine(iCollection.Count);
+        foreach (var obj in iCollection)
+        {
+            var pair = (KeyValuePair<string, int>) obj;
+            Console.WriteLine(pair.Key);
+            Console.WriteLine(pair.Value);
+        }
+
+        var genericIEnumerable = GetFilledGenericIEnumerable();
+        foreach (var pair in genericIEnumerable)
+        {
+            Console.WriteLine(pair.Key);
+            Console.WriteLine(pair.Value);
+        }
+
+        var iEnumerable = GetFilledIEnumerable();
+        foreach (var obj in iEnumerable)
+        {
+            var pair = (KeyValuePair<string, int>)obj;
+            Console.WriteLine(pair.Key);
+            Console.WriteLine(pair.Value);
+        }
+    }
+
+    public static IEnumerable GetFilledIEnumerable()
+    {
+        return CreateAndFill();
+    }
+
+    public static IEnumerable<KeyValuePair<string, int>> GetFilledGenericIEnumerable()
+    {
+        return CreateAndFill();
+    }
+    
+    public static ICollection GetFilledICollection()
+    {
+        return CreateAndFill();
+    }
+
+    public static ICollection<KeyValuePair<string, int>> GetFilledGenericICollection()
+    {
+        return CreateAndFill();
+    }
+
+    public static IDictionary GetFilledIDictionary()
+    {
+        return CreateAndFill();
+    }
+
+    public static IDictionary<string, int> GetFilledGenericIDictionary()
+    {
+        return CreateAndFill();
+    }
+
+    public static Dictionary<string, int> CreateAndFill()
+    {
+        return new Dictionary<string, int> {
+            {"a", 1},
+            {"b", 2},
+            {"z", 3},
+            {"c", 4}
+        };
+    }
+}

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -826,6 +826,7 @@
 	<None Include="SimpleTestCases\InterfaceGenericCall_Issue348.cs" />
 	<None Include="SimpleTestCases\InnerClassNameInLibrary_Issue352.cs" />
 	<None Include="SpecialTestCases\InnerClassNameFormatting_Issue352.cs" />
+	<None Include="TestCases\DictionaryInterfaces.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\JSIL\JSIL.csproj">


### PR DESCRIPTION
With last changes, JSIL are now much more strict with interface method implementation. As IDictionary.Values and IDictionary.Keys has signature different from Dictionary.Values and Dictionary.Keys, JSIL after last update cannot find IDictionary method implementations in Dictionary. I return it back.
