### PR TITLE
Typed array IEnumerable<T>.GetEnumerator fixed (#353).

### DIFF
--- a/Libraries/JSIL.Core.js
+++ b/Libraries/JSIL.Core.js
@@ -8671,21 +8671,20 @@ JSIL.$GetStringEnumerator = function () {
     return JSIL.GetEnumerator(this, $jsilcore.System.Char.__Type__, true);  
 };
 
-JSIL.$GetArrayEnumerator = function () {
-    return JSIL.GetEnumerator(this, $jsilcore.System.Object.__Type__, true);
-};
-
 JSIL.$GetEnumeratorFallback = function (signature, thisReference) {
   if (typeof (thisReference) === "string") {
     return JSIL.$GetStringEnumerator;
-  } else if (JSIL.IsArray(thisReference)) { 
-    // HACK: Too hard to detect the correct element type here.
-    return JSIL.$GetArrayEnumerator;
+  } else if (JSIL.IsArray(thisReference)) {
+    var enumeratorTypeArgument = $jsilcore.System.Object.__Type__;
+    if (this.typeObject.IsGenericType) {
+      enumeratorTypeArgument = this.typeObject.__GenericArgumentValues__[0];
+    }
+    return function () { return JSIL.GetEnumerator(this, enumeratorTypeArgument, true); };
   } else
     JSIL.RuntimeError("Object of type '" + JSIL.GetType(this) + "' has no implementation of " + signature.toString("GetEnumerator"));
 };
 
-// FIXME: This can probably be replaced with compiler and/or runtime intelligence 
+// FIXME: This can probably be replaced with compiler and/or runtime intelltypeigence 
 //  to create interface overlays for strings, just like arrays.
 JSIL.$PickFallbackMethodForInterfaceMethod = function (interfaceObject, methodName, signature) {
   // HACK: Ensures that you can enumerate the chars of a JS string or array in cases where they lack an overlay.

--- a/Tests/SimpleTestCases/TypedArrayEnumerator_Issue353.cs
+++ b/Tests/SimpleTestCases/TypedArrayEnumerator_Issue353.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+
+public static class Program
+{
+    public static void Main(string[] args)
+    {
+        var item = TestInnerArrayCast(GetItems(), it => new[] { it });
+        Console.WriteLine(item.GetType().FullName);
+    }
+
+    private static IEnumerable<BaseClass> GetItems()
+    {
+        return new List<DerivedClass>() { new DerivedClass() };
+    }
+
+    public static BaseClass TestInnerArrayCast(IEnumerable<BaseClass> source, Func<BaseClass, IEnumerable<BaseClass>> selector)
+    {
+        var outerEnumerator = source.GetEnumerator();
+        outerEnumerator.MoveNext();
+
+        var inner = selector(outerEnumerator.Current);
+        var innerEnumerator = inner.GetEnumerator();
+        innerEnumerator.MoveNext();
+
+        return innerEnumerator.Current;
+    }
+}
+
+public class BaseClass
+{
+}
+
+public class DerivedClass : BaseClass
+{
+}

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -832,6 +832,7 @@
     <None Include="SimpleTestCases\InnerClassNameInLibrary_Issue352.cs" />
     <None Include="SpecialTestCases\InnerClassNameFormatting_Issue352.cs" />
     <None Include="TestCases\DictionaryInterfaces.cs" />
+	<None Include="SimpleTestCases\TypedArrayEnumerator_Issue353" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\JSIL\JSIL.csproj">


### PR DESCRIPTION
It's a little bit updated fix, that I've suggested in #353 discussion. Thanks to your last refactoring we can easily find proper IEnumerator type.
