### PR TITLE
Added sorting in $BuildMethodGroups based on distance from type. 

### DIFF
--- a/Libraries/JSIL.Core.js
+++ b/Libraries/JSIL.Core.js
@@ -4056,6 +4056,13 @@ JSIL.$BuildMethodGroups = function (typeObject, publicInterface, forceLazyMethod
 
     JSIL.$ApplyMemberHiding(typeObject, methodList, resolveContext);
   }
+  
+  var record = function (distance, signature) {
+    this.distance = distance;
+    this.signature = signature;
+  };
+  
+  var typesHiearchy = JSIL.GetTypeAndBases(typeObject); 
 
   for (var key in methodsByName) {
     var methodList = methodsByName[key];
@@ -4065,12 +4072,23 @@ JSIL.$BuildMethodGroups = function (typeObject, publicInterface, forceLazyMethod
     var isStatic = methodList[0]._descriptor.Static;
     var signature = methodList[0]._data.signature;
 
-    var entries = [];
+    var entriesToSort = []; 
 
     for (var i = 0, l = methodList.length; i < l; i++) {
-      var method = methodList[i];
+       var method = methodList[i];
+       entriesToSort.push(new record(typesHiearchy.indexOf(method._typeObject), method._data.signature));
+    }
+    
+    entriesToSort.sort(function (lhs, rhs) {
+      return JSIL.CompareValues(lhs.distance, rhs.distance);
+    });
 
-      entries.push(method._data.signature);
+    var entries = [];
+
+    for (var i = 0, l = entriesToSort.length; i < l; i++) {
+      var method = entriesToSort[i];
+
+      entries.push(method.signature);
     }
 
     var target = isStatic ? publicInterface : publicInterface.prototype;

--- a/Tests/SimpleTestCases/Issue368.cs
+++ b/Tests/SimpleTestCases/Issue368.cs
@@ -1,0 +1,76 @@
+﻿using System;
+
+public static class Program
+{
+    public static void Main(string[] args)
+    {
+        var br = new BaseResult();
+        var dr = new DerivedResult();
+
+        var bas = new Base();
+        var derived = new Derived();
+
+        bas.Method();
+        bas.MethodWithParameter1(br);
+        bas.MethodWithParameter1(dr);
+        bas.MethodWithParameter2(dr);
+
+        bas = derived;
+        bas.Method();
+        bas.MethodWithParameter1(br);
+        bas.MethodWithParameter1(dr);
+        bas.MethodWithParameter2(dr);
+
+        derived.Method();
+        derived.MethodWithParameter1(br);
+        derived.MethodWithParameter1(dr);
+        derived.MethodWithParameter2(br);
+        derived.MethodWithParameter2(dr);
+    }
+}
+
+public class Base
+{
+    public BaseResult Method()
+    {
+        Console.WriteLine("Base Method");
+        return null;
+    }
+
+    public void MethodWithParameter1(BaseResult r1)
+    {
+        Console.WriteLine("Base MethodWithParameter1");
+    }
+
+    public void MethodWithParameter2(DerivedResult r1)
+    {
+        Console.WriteLine("Base MethodWithParameter2");
+    }
+}
+
+public class Derived : Base
+{
+    public DerivedResult Method()
+    {
+        Console.WriteLine("Derived Method");
+        return null;
+    }
+
+    public void MethodWithParameter1(DerivedResult r1)
+    {
+        Console.WriteLine("Derived MethodWithParameter1");
+    }
+
+    public void MethodWithParameter2(BaseResult r1)
+    {
+        Console.WriteLine("Derived MethodWithParameter2");
+    }
+}
+
+public class BaseResult
+{
+}
+
+public class DerivedResult : BaseResult
+{
+}

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -853,6 +853,7 @@
     <None Include="SimpleTestCases\Issue364_1.cs" />
     <None Include="SimpleTestCases\Issue364_2.cs" />
     <None Include="SimpleTestCases\Issue364_3.cs" />
+    <None Include="SimpleTestCases\Issue368.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\JSIL\JSIL.csproj">


### PR DESCRIPTION
I suppose here is proper fix for #368. I added sorting on creating method groups based on distance from method declared type to building type, same as was done for interfaces. It fixes problem with incorrect overload selecting in OverloadedMethod_InvokeDynamic, as it tries to find correct method testing them one-by-one.
