### PR TITLE
Do not add MethodSignatures to parent/child types for static methods

### DIFF
--- a/JSIL/TypeInformation.cs
+++ b/JSIL/TypeInformation.cs
@@ -463,6 +463,7 @@ namespace JSIL.Internal {
         protected bool _MethodGroupsInitialized = false;
 
         protected List<NamedMethodSignature> DeferredMethodSignatureSetUpdates = new List<NamedMethodSignature>();
+        protected List<NamedMethodSignature> DeferredStaticMethodSignatureSetUpdates = new List<NamedMethodSignature>();
 
         public TypeInfo (ITypeInfoSource source, ModuleInfo module, TypeDefinition type, TypeInfo declaringType, TypeInfo baseClass, TypeIdentifier identifier) {
             Identifier = identifier;
@@ -740,8 +741,11 @@ namespace JSIL.Internal {
                 }
             }
 
-            //DeferredMethodSignatureSetUpdates.Clear();
-            //DeferredMethodSignatureSetUpdates = null;
+            foreach (var nms in DeferredStaticMethodSignatureSetUpdates)
+            {
+                var set = MethodSignatures.GetOrCreateFor(nms.Name);
+                set.Add(nms);
+            }
         }
 
         public bool IsFullyInitialized {
@@ -1132,8 +1136,12 @@ namespace JSIL.Internal {
             if (!Members.TryAdd(identifier, result))
                 throw new InvalidOperationException();
 
-            DeferredMethodSignatureSetUpdates.Add(((MethodInfo)result).NamedSignature);
-
+            if (method.IsStatic || method.IsConstructor) {
+                DeferredStaticMethodSignatureSetUpdates.Add(((MethodInfo)result).NamedSignature);
+            }
+            else {
+                DeferredMethodSignatureSetUpdates.Add(((MethodInfo)result).NamedSignature);
+            }
             return (MethodInfo)result;
         }
 
@@ -1147,7 +1155,12 @@ namespace JSIL.Internal {
             if (!Members.TryAdd(identifier, result))
                 throw new InvalidOperationException();
 
-            DeferredMethodSignatureSetUpdates.Add(((MethodInfo)result).NamedSignature);
+            if (method.IsStatic || method.IsConstructor) {
+                DeferredStaticMethodSignatureSetUpdates.Add(((MethodInfo)result).NamedSignature);
+            }
+            else {
+                DeferredMethodSignatureSetUpdates.Add(((MethodInfo)result).NamedSignature);
+            }
 
             return (MethodInfo)result;
         }
@@ -1164,8 +1177,12 @@ namespace JSIL.Internal {
 
             if (method.Name == ".cctor")
                 StaticConstructor = method;
-
-            DeferredMethodSignatureSetUpdates.Add(((MethodInfo)result).NamedSignature);
+            if (method.IsStatic || method.IsConstructor) {
+                DeferredStaticMethodSignatureSetUpdates.Add(((MethodInfo)result).NamedSignature);
+            }
+            else {
+                DeferredMethodSignatureSetUpdates.Add(((MethodInfo)result).NamedSignature);
+            }
 
             return (MethodInfo)result;
         }


### PR DESCRIPTION
As I found when investigated #504, after my change from #476, JSIL always used constructor signature for constructor calls. It happened, because now we add to overload list counter not only methods from derived class, but from base class also.
So, for every class we added .ctor from object - so any class had overloaded .ctor according to our meta info, and .ctor never use fast dispatcher - so even if we had another signature, we still used constructor signature for it.

Really, we don't need add constructors and static methods to overload list counter of base/derived classes, as we always call them with knowledge of class on which it is called. We need add it count only to class on which static method/constructor was defined. I implemented it with this pull request. 

With this patch we could reproduce #504 only with second test case (as were before #476), or if we add one more constructor to GenericClass.
