### PR TITLE
Removed call of JSIL.ImplementExternals with $jsilcore.MemberInfoExternals

### DIFF
--- a/Libraries/JSIL.Core.Reflection.js
+++ b/Libraries/JSIL.Core.Reflection.js
@@ -565,14 +565,6 @@ JSIL.ImplementExternals(
 );
 
 JSIL.ImplementExternals(
-  "System.Reflection.PropertyInfo", $jsilcore.MemberInfoExternals
-);
-
-JSIL.ImplementExternals(
-  "System.Reflection.FieldInfo", $jsilcore.MemberInfoExternals
-);
-
-JSIL.ImplementExternals(
   "System.Reflection.MethodBase", function ($) {
     $.Method({Static:false, Public:false}, "GetParameterTypes", 
       (new JSIL.MethodSignature($jsilcore.TypeRef("System.Array", [$jsilcore.TypeRef("System.Type")]), [], [])), 


### PR DESCRIPTION
As we discussed in #518.
