### PR TITLE
Added BCL proxies for classes implemented in JSIL.Async.js

### DIFF
--- a/Proxies/BCL/JSIL.Async.cs
+++ b/Proxies/BCL/JSIL.Async.cs
@@ -1,0 +1,78 @@
+﻿using System.Threading.Tasks;
+
+using JSIL.Meta;
+using JSIL.Proxy;
+
+namespace JSIL.Proxies.Bcl
+{
+    [JSProxy("System.Runtime.CompilerServices.AsyncVoidMethodBuilder", JSProxyMemberPolicy.ReplaceNone, JSProxyAttributePolicy.ReplaceDeclared,
+        JSProxyInterfacePolicy.ReplaceNone, false)]
+    [JSStubOnly]
+    public class System_Runtime_CompilerServices_AsyncVoidMethodBuilder
+    {
+    }
+
+    [JSProxy("System.Runtime.CompilerServices.AsyncVoidMethodBuilder`1", JSProxyMemberPolicy.ReplaceNone, JSProxyAttributePolicy.ReplaceDeclared,
+        JSProxyInterfacePolicy.ReplaceNone, false)]
+    [JSStubOnly]
+    public class System_Runtime_CompilerServices_AsyncTaskMethodBuilder
+    {
+    }
+
+    [JSProxy("System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1", JSProxyMemberPolicy.ReplaceNone, JSProxyAttributePolicy.ReplaceDeclared,
+        JSProxyInterfacePolicy.ReplaceNone, false)]
+    [JSStubOnly]
+    public class System_Runtime_CompilerServices_AsyncTaskMethodBuilder_1
+    {
+    }
+
+    [JSProxy(typeof(Task), JSProxyMemberPolicy.ReplaceNone, JSProxyAttributePolicy.ReplaceDeclared,
+        JSProxyInterfacePolicy.ReplaceNone, false)]
+    [JSStubOnly]
+    public class System_Threading_Tasks_Tasks
+    {
+    }
+
+    [JSProxy(typeof(Task<>), JSProxyMemberPolicy.ReplaceNone, JSProxyAttributePolicy.ReplaceDeclared,
+        JSProxyInterfacePolicy.ReplaceNone, false)]
+    [JSStubOnly]
+    public class System_Threading_Tasks_Tasks_1
+    {
+    }
+
+
+    [JSProxy(typeof(TaskCompletionSource<>), JSProxyMemberPolicy.ReplaceNone, JSProxyAttributePolicy.ReplaceDeclared,
+        JSProxyInterfacePolicy.ReplaceNone, false)]
+    [JSStubOnly]
+    public class System_Threading_Tasks_TaskCompletionSource_1
+    {
+    }
+
+    [JSProxy(typeof(TaskFactory), JSProxyMemberPolicy.ReplaceNone, JSProxyAttributePolicy.ReplaceDeclared,
+        JSProxyInterfacePolicy.ReplaceNone, false)]
+    [JSStubOnly]
+    public class System_Threading_Tasks_TaskFactory
+    {
+    }
+
+    [JSProxy(typeof(TaskFactory<>), JSProxyMemberPolicy.ReplaceNone, JSProxyAttributePolicy.ReplaceDeclared,
+        JSProxyInterfacePolicy.ReplaceNone, false)]
+    [JSStubOnly]
+    public class System_Threading_Tasks_TaskFactory_1
+    {
+    }
+
+    [JSProxy("System.Runtime.CompilerServices.TaskAwaiter", JSProxyMemberPolicy.ReplaceNone, JSProxyAttributePolicy.ReplaceDeclared,
+        JSProxyInterfacePolicy.ReplaceNone, false)]
+    [JSStubOnly]
+    public class System_Runtime_CompilerServices_TaskAwaiter
+    {
+    }
+
+    [JSProxy("System.Runtime.CompilerServices.TaskAwaiter`1", JSProxyMemberPolicy.ReplaceNone, JSProxyAttributePolicy.ReplaceDeclared,
+        JSProxyInterfacePolicy.ReplaceNone, false)]
+    [JSStubOnly]
+    public class System_Runtime_CompilerServices_TaskAwaiter_1
+    {
+    }
+}

--- a/Proxies/BCL/Proxies.Bcl.csproj
+++ b/Proxies/BCL/Proxies.Bcl.csproj
@@ -35,6 +35,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="JSIL.Async.cs" />
     <Compile Include="JSIL.Bootstrap.cs" />
     <Compile Include="JSIL.Bootstrap.DateTime.cs" />
     <Compile Include="JSIL.Bootstrap.Linq.cs" />


### PR DESCRIPTION
Realized, that I forget provide BCL proxies for newly implemented in JS classes for async support. Here they are.
