### PR TITLE
Fixed incorrect GenericParameter reference in JSIL.CloneParameter (#579)

### DIFF
--- a/JSIL/JavascriptFormatter.cs
+++ b/JSIL/JavascriptFormatter.cs
@@ -813,8 +813,13 @@ namespace JSIL.Internal {
 
         protected bool EmitThisForParameter (GenericParameter gp) {
             var tr = gp.Owner as TypeReference;
-            if (tr != null)
+            if (tr != null
+                && (CurrentMethod == null
+                || (CurrentMethod.DeclaringType.GenericParameters != null
+                && CurrentMethod.DeclaringType.GenericParameters.Any(p => p.Name == gp.Name))))
+            {
                 return true;
+            }
 
             return false;
         }

--- a/Tests/SimpleTestCases/Issue579.cs
+++ b/Tests/SimpleTestCases/Issue579.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+public static class Program
+{
+    public static void Main(string[] args)
+    {
+        var signal1 = new ManualResetEventSlim(false);
+        var signal2 = new ManualResetEventSlim(false);
+
+        var t1 = new TaskCompletionSource<object>();
+        var t2 = new TaskCompletionSource<object>();
+
+        DoWork(t1.Task, 1).ContinueWith(
+            pre =>
+            {
+                if (!JSIL.Builtins.IsJavascript)
+                    Console.Out.Flush();
+
+                signal1.Set();
+            });
+
+        DoWork(t2.Task, 2).ContinueWith(
+            pre =>
+            {
+                if (!JSIL.Builtins.IsJavascript)
+                    Console.Out.Flush();
+
+                signal2.Set();
+            });
+
+        t1.TrySetResult(new object());
+        t2.TrySetResult(new object());
+
+        signal1.Wait();
+        signal2.Wait();
+    }
+
+    public static async Task DoWork(Task waitFor, int index)
+    {
+        Console.WriteLine("Started: " + index);
+        await Program.RunTaskWithTwoInterceptors(
+            "input",
+            async () =>
+                {
+                    Console.WriteLine("Inner begin");
+                    await waitFor;
+                });
+
+        Console.WriteLine("Finished: " + index);
+    }
+
+    public static async Task TaskInterceptor(object target, Func<Task> func)
+    {
+        Console.WriteLine(target);
+        await func();
+    }
+
+    public static Task RunTaskWithTwoInterceptors<TController>(
+        TController target,
+        Func<Task> func)
+    {
+        return TaskInterceptor(
+            target,
+            async () => await TaskInterceptor(target, func));
+    }
+}

--- a/Tests/SimpleTests.csproj
+++ b/Tests/SimpleTests.csproj
@@ -388,6 +388,7 @@
     <None Include="SimpleTestCases\LambdaInStateMachine1_Issue544.cs" />
     <None Include="SimpleTestCases\LambdaInStateMachine2_Issue544.cs" />
     <None Include="SimpleTestCases\HelloWorld.il" />
+    <None Include="SimpleTestCases\Issue579.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\JSIL\JSIL.csproj">


### PR DESCRIPTION
I've fixed issue and doesn't break any tests. Still it will be good to review, what should return `EmitThisForParameter` if `CurrentMethod == null`.
Currently I make it return true, as it works before my patch. You could check on which condition `CurrentMethod == null` through SimpleTestCasesForTranslatedBcl\ExpressionsTest.
