### PR TITLE
Fixed external implementation for private types (#578).

### DIFF
--- a/Libraries/JSIL.Core.js
+++ b/Libraries/JSIL.Core.js
@@ -245,6 +245,7 @@ JSIL.$AssignedTypeIds = {};
 JSIL.$GenericParameterTypeIds = {};
 JSIL.$PublicTypes = {};
 JSIL.$PublicTypeAssemblies = {};
+JSIL.$PrivateTypeAssemblies = {};
 JSIL.$EntryPoints = {};
 
 
@@ -413,8 +414,10 @@ JSIL.AssignTypeId = function (assembly, typeName) {
 
   if (typeof (JSIL.$PublicTypeAssemblies[typeName]) !== "undefined") {
     assembly = JSIL.$PublicTypeAssemblies[typeName];
+  } else if (typeof (JSIL.$PrivateTypeAssemblies[typeName]) !== "undefined") {
+    assembly = JSIL.$PrivateTypeAssemblies[typeName];
   }
-
+  
   var key = assembly.__AssemblyId__ + "$" + typeName;
   var result = JSIL.$AssignedTypeIds[key];
 
@@ -1123,7 +1126,26 @@ JSIL.DefineTypeName = function (name, getter, isPublic) {
       JSIL.$PublicTypes[key] = getter;
       JSIL.$PublicTypeAssemblies[key] = $private;
     }
-  }
+  } else if ($private == $jsilcore) {
+      var key = JSIL.EscapeName(name);
+
+      JSIL.$PrivateTypeAssemblies[key] = $private;  
+  } else {
+      var key = JSIL.EscapeName(name);
+      
+      var existing = JSIL.$PrivateTypeAssemblies[key];
+      
+      if (existing !== undefined){
+        if (existing != $jsilcore) {
+          JSIL.Host.warning(
+            "Private type '" + name + "' with external implementation defined more than twice: " + 
+            $private.toString() + " and " + existing.toString()
+          );
+        }
+
+        JSIL.$PrivateTypeAssemblies[key] = $private;
+      }      
+  }  
 
   var existing = $private.$typesByName[name];
   if (typeof (existing) === "function")

--- a/Tests/SimpleTestCasesForStubbedBcl/Issue578.cs
+++ b/Tests/SimpleTestCasesForStubbedBcl/Issue578.cs
@@ -1,0 +1,19 @@
+﻿﻿using System;
+using System.Collections.Generic;
+
+class Program {
+    public static void Main () {
+        var hs = new HashSet<string>() {
+            "a",
+            "b",
+            "c"
+        };
+
+        foreach (var s in hs)
+            Console.WriteLine(s);
+
+        Console.WriteLine(hs.Count);
+
+        var test = hs.GetEnumerator();
+    }
+}

--- a/Tests/SimpleTests.csproj
+++ b/Tests/SimpleTests.csproj
@@ -80,6 +80,7 @@
     <None Include="SimpleTestCases\DelegateMethod_Issue604.cs" />
     <None Include="ExpressionTestCases\ExpressionsExecution.cs" />
     <None Include="SimpleTestCases\CharArithmetic_Issue610.cs" />
+    <None Include="SimpleTestCasesForStubbedBcl\Issue578.cs" />
     <Compile Include="SimpleTestCases\ReflectionGenericMethodInvoke.cs" />
     <Compile Include="SimpleTests.cs" />
     <None Include="SimpleTestCases\BaseAutoProperties.cs" />


### PR DESCRIPTION
Fix for external implementation of private classes (#578).
Note: If $jsilcore contains implementation for private type, private type with same name will have same TypeId.
Maybe we should find better solution or correctly define assembly for classes in External Implementations. On other side, public classes work same way now.
