### PR TITLE
Fixed initializer for read only properties

### DIFF
--- a/Libraries/JSIL.Core.Types.js
+++ b/Libraries/JSIL.Core.Types.js
@@ -44,7 +44,10 @@ JSIL.ImplementExternals("System.Object", function ($) {
         var value = initializer[key];
 
         if (isInitializer(value)) {
-          this[key] = value.Apply(this[key]);
+          var result = value.Apply(this[key]);
+          if (result !== undefined) {
+            this[key] = result;
+          }
         } else {
           this[key] = value;
         }
@@ -156,8 +159,6 @@ JSIL.MakeClass("System.Object", "JSIL.CollectionInitializer", true, [], function
   $.RawMethod(false, "Apply",
     function (previousValue) {
       JSIL.ApplyCollectionInitializer(previousValue, this.values);
-
-      return previousValue;
     }
   );
 });
@@ -180,7 +181,7 @@ JSIL.MakeClass("System.Object", "JSIL.ObjectInitializer", true, [], function ($)
       else
         JSIL.Host.warning("Object initializer applied to null/undefined!");
 
-      return result;
+      return this.hasInstance ? result : undefined;
     }
   );
 });

--- a/Tests/SimpleTestCases/ReadOnlyPropretiesInitiallizer_Issue619.cs
+++ b/Tests/SimpleTestCases/ReadOnlyPropretiesInitiallizer_Issue619.cs
@@ -1,0 +1,31 @@
+using System;
+
+public static class Program
+{
+    public static void Main(string[] args)
+    {
+        var instance = new ClassWithReadOnlyProperty
+        {
+            Property = { SomeString = "Modified" }
+        };
+
+        Console.WriteLine(instance.Property.SomeString);
+    }
+}
+
+public class ClassWithReadOnlyProperty
+{
+    private ComplexProperty _property = new ComplexProperty {SomeString = "Initial"};
+
+    public ComplexProperty Property
+    {
+        get { return _property; }
+    }
+}
+
+
+public class ComplexProperty 
+{
+    public string SomeString { get; set; }
+}
+

--- a/Tests/SimpleTests.csproj
+++ b/Tests/SimpleTests.csproj
@@ -80,6 +80,7 @@
     <None Include="SimpleTestCases\DelegateMethod_Issue604.cs" />
     <None Include="ExpressionTestCases\ExpressionsExecution.cs" />
     <None Include="SimpleTestCases\CharArithmetic_Issue610.cs" />
+    <None Include="SimpleTestCases\ReadOnlyPropretiesInitiallizer_Issue619.cs" />
     <Compile Include="SimpleTestCases\ReflectionGenericMethodInvoke.cs" />
     <Compile Include="SimpleTests.cs" />
     <None Include="SimpleTestCases\BaseAutoProperties.cs" />


### PR DESCRIPTION
Fix for (#619).
Not best implementation - really it would be better don't write `JSIL.ObjectInitializer` at all if we create new object and use it only if we just modify properties.