### PR TITLE
Fixed DCE: always add declaring type for added field.

### DIFF
--- a/Compiler/Analyzers/DeadCodeAnalyzer/DeadCodeInfoProvider.cs
+++ b/Compiler/Analyzers/DeadCodeAnalyzer/DeadCodeInfoProvider.cs
@@ -356,6 +356,7 @@ namespace JSIL.Compiler.Extensibility.DeadCodeAnalyzer {
             }
 
             AddType(field.FieldType);
+            AddType(field.DeclaringType);
             FieldDefinition resolvedField = field.Resolve();
 
             fields.Add(resolvedField);


### PR DESCRIPTION
Small fix to preserve type declaration if we has use any fields from it. Should help if we init `int` variable from `enum` type and it is only `enum` type usage.
