### PR TITLE
IsAssignableFrom always true for Object (#560)

### DIFF
--- a/Libraries/JSIL.Core.js
+++ b/Libraries/JSIL.Core.js
@@ -5410,9 +5410,15 @@ JSIL.MakeType = function (typeArgs, initializer) {
       typeObject.__IsClosed__ = (baseType.__IsClosed__ !== false);
     }
 
-    typeObject._IsAssignableFrom = function (typeOfValue) {
-      return typeOfValue.__AssignableTypes__[this.__TypeId__] === true;
-    };
+    if (fullName === "System.Object") {
+      typeObject._IsAssignableFrom = function (typeOfValue) {
+        return true;
+      };
+    } else {
+      typeObject._IsAssignableFrom = function (typeOfValue) {
+        return typeOfValue.__AssignableTypes__[this.__TypeId__] === true;
+      };
+    }
 
     for (var i = 0, l = typeObject.__GenericArguments__.length; i < l; i++) {
       var ga = typeObject.__GenericArguments__[i];

--- a/Tests/SimpleTestCases/Issue560.cs
+++ b/Tests/SimpleTestCases/Issue560.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+public static class Program {
+    public static void Main() {
+        int x = 5;
+        if (typeof(object).IsAssignableFrom(x.GetType())) {
+            Console.WriteLine("Passed");
+        };
+    }
+}

--- a/Tests/SimpleTests.csproj
+++ b/Tests/SimpleTests.csproj
@@ -85,6 +85,7 @@
     <None Include="SimpleTestCasesForStubbedBcl\Issue578.cs" />
     <None Include="SimpleTestCases\Issue631.cs" />
     <None Include="SimpleTestCases\Issue555.cs" />
+    <None Include="SimpleTestCases\Issue560.cs" />
     <Compile Include="SimpleTestCases\ReflectionGenericMethodInvoke.cs" />
     <Compile Include="SimpleTests.cs" />
     <None Include="SimpleTestCases\BaseAutoProperties.cs" />


### PR DESCRIPTION
Fixes #560 by adding a special case version of _IsAssignableFrom for System.Object