### PR TITLE
Don't treat bool as integer for casting (#478)

### DIFF
--- a/Libraries/JSIL.Core.js
+++ b/Libraries/JSIL.Core.js
@@ -2025,12 +2025,16 @@ JSIL.MakeNumericType = function (baseType, typeName, isIntegral, typedArrayName)
       $.SetValue("__TypedArray__", null);
     }
 
-    var castSpecialType =
-      (typeName === "System.Char")
-        ? "char"
-        : isIntegral 
-          ? "integer" 
-          : "number";
+    var castSpecialType;
+    if (typeName === "System.Char") {
+      castSpecialType = "char";
+    } else if (typeName == "System.Boolean") {
+      castSpecialType = "bool";
+    } else if (isIntegral) {
+      castSpecialType = "integer";
+    } else {
+      castSpecialType = "number";
+    }
 
     JSIL.MakeCastMethods(
       $.publicInterface, $.typeObject, castSpecialType

--- a/Tests/SimpleTestCases/Issue478.cs
+++ b/Tests/SimpleTestCases/Issue478.cs
@@ -1,0 +1,42 @@
+﻿using System;
+
+public static class Program {
+    public static void Main(string[] args) {
+        object obj = "string";
+        obj = Hello.One;
+        Console.WriteLine((int)obj); //Output: 52
+        Console.WriteLine((System.Int32)obj); //Output : 52
+
+        try {
+            Console.WriteLine((float)obj);
+        } catch (System.InvalidCastException) {
+            Console.WriteLine("invalid cast exception (float)");
+        }
+
+        try {
+            Console.WriteLine((bool)obj);
+        }
+        catch (System.InvalidCastException) {
+            Console.WriteLine("invalid cast exception (bool)");
+        }
+
+        try {
+            Console.WriteLine((string)obj);
+        }
+        catch (System.InvalidCastException) {
+            Console.WriteLine("invalid cast exception (string)");
+        }
+
+        try {
+            Console.WriteLine((System.Int64)obj);
+        }
+        catch (System.InvalidCastException) {
+            Console.WriteLine("invalid cast exception (System.Int64)");
+        }
+    }
+
+    public enum Hello {
+        One = 52,
+        Two
+    }
+}

--- a/Tests/SimpleTests.csproj
+++ b/Tests/SimpleTests.csproj
@@ -85,6 +85,7 @@
     <None Include="SimpleTestCasesForStubbedBcl\Issue578.cs" />
     <None Include="SimpleTestCases\Issue631.cs" />
     <None Include="SimpleTestCases\Issue555.cs" />
+    <None Include="SimpleTestCases\Issue478.cs" />
     <Compile Include="SimpleTestCases\ReflectionGenericMethodInvoke.cs" />
     <Compile Include="SimpleTests.cs" />
     <None Include="SimpleTestCases\BaseAutoProperties.cs" />


### PR DESCRIPTION
Giving it a separate castSpecialType means casting to bool will use the default castFunction instead, raising an InvalidCastException.