### PR TITLE
PassDelegateInStruct fails with ushort in struct

### DIFF
--- a/Tests/EmscriptenTestCases/PassDelegateInStruct.cs
+++ b/Tests/EmscriptenTestCases/PassDelegateInStruct.cs
@@ -10,6 +10,7 @@ public static unsafe class Program {
 
     [StructLayout(LayoutKind.Sequential)]
     public struct CallbackStruct {
+        public ushort us;
         public Callback callback;
     }
 
@@ -20,7 +21,7 @@ public static unsafe class Program {
         Callback c = PrintSuccess;
         var cHandle = GCHandle.Alloc(c);
 
-        var s = new CallbackStruct { callback = c };
+        var s = new CallbackStruct { us = 4, callback = c };
         CallFunctionInStruct(s, 747);
     }
 

--- a/Tests/EmscriptenTestCases/common/common.cpp
+++ b/Tests/EmscriptenTestCases/common/common.cpp
@@ -15,6 +15,7 @@ struct TestStruct {
 };
 
 struct CallbackStruct {
+	unsigned short us;
 	void(*callback)(int i);
 };
 


### PR DESCRIPTION
"Uncaught RangeError: start offset of Int32Array should be a multiple of 4"

Only seems to happen for the struct which also has a function pointer.