### PR TITLE
CustomStringMarshaler test case

### DIFF
--- a/Tests/EmscriptenTestCases/CustomStringMarshaler.cs
+++ b/Tests/EmscriptenTestCases/CustomStringMarshaler.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Text;
+using System.Runtime.InteropServices;
+
+public static class Program {
+    internal unsafe class LPUtf8StrMarshaler : ICustomMarshaler {
+        public const string LeaveAllocated = "LeaveAllocated";
+
+        private static ICustomMarshaler
+            _leaveAllocatedInstance = new LPUtf8StrMarshaler(true),
+            _defaultInstance = new LPUtf8StrMarshaler(false);
+
+        public static ICustomMarshaler GetInstance(string cookie) {
+            switch (cookie) {
+                case "LeaveAllocated":
+                    return _leaveAllocatedInstance;
+                default:
+                    return _defaultInstance;
+            }
+        }
+
+        private bool _leaveAllocated;
+
+        public LPUtf8StrMarshaler(bool leaveAllocated) {
+            _leaveAllocated = leaveAllocated;
+        }
+
+        public object MarshalNativeToManaged(IntPtr pNativeData) {
+            if (pNativeData == IntPtr.Zero)
+                return null;
+            var ptr = (byte*)pNativeData;
+            while (*ptr != 0) {
+                ptr++;
+            }
+            var bytes = new byte[ptr - (byte*)pNativeData];
+            Marshal.Copy(pNativeData, bytes, 0, bytes.Length);
+            return Encoding.UTF8.GetString(bytes);
+        }
+
+        public IntPtr MarshalManagedToNative(object ManagedObj) {
+            if (ManagedObj == null)
+                return IntPtr.Zero;
+            var str = ManagedObj as string;
+            if (str == null) {
+                throw new ArgumentException("ManagedObj must be a string.", "ManagedObj");
+            }
+            var bytes = Encoding.UTF8.GetBytes(str);
+            var mem = Marshal.AllocHGlobal(bytes.Length + 1);
+            Marshal.Copy(bytes, 0, mem, bytes.Length);
+            ((byte*)mem)[bytes.Length] = 0;
+            return mem;
+        }
+
+        public void CleanUpManagedData(object ManagedObj) {
+        }
+
+        public void CleanUpNativeData(IntPtr pNativeData) {
+            if (!_leaveAllocated) {
+                Marshal.FreeHGlobal(pNativeData);
+            }
+        }
+
+        public int GetNativeDataSize() {
+            return -1;
+        }
+    }
+
+    [DllImport("common.dll", CallingConvention=CallingConvention.Cdecl)]
+    [return: MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(LPUtf8StrMarshaler), MarshalCookie = LPUtf8StrMarshaler.LeaveAllocated)]
+    public static extern string ReturnString();
+
+    public static void Main () {
+        Console.WriteLine(ReturnString());
+    }
+}

--- a/Tests/EmscriptenTestCases/common/common.cpp
+++ b/Tests/EmscriptenTestCases/common/common.cpp
@@ -47,6 +47,10 @@ export(TestStruct) ReturnStructArgument (const TestStruct arg) {
     return arg;
 }
 
+export(const char *) ReturnString() {
+	return "butts";
+}
+
 export(void) MutateStringArgument (char * buf, const int capacity) {
     // #%(*#@%OJIJ#LW% i hate clang
     // strcat_s(buf, capacity, " world");

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -137,6 +137,7 @@
     <None Include="EmscriptenTestCases\OutUshortArrayParameter.cs" />
     <None Include="EmscriptenTestCases\ByValueStructParameter_Small.cs" />
     <None Include="EmscriptenTestCases\PassIntPtrInStruct.cs" />
+    <None Include="EmscriptenTestCases\CustomStringMarshaler.cs" />
     <Compile Include="EmscriptenTests.cs" />
     <Compile Include="CodeProviders.cs">
       <SubType>Component</SubType>


### PR DESCRIPTION
Comes from SDL2-CS, which returns all native strings using LPUtf8StrMarshaler