### PR TITLE
Fixed incorrect string escape for null-byte following digit char.

### DIFF
--- a/JSIL/Util.cs
+++ b/JSIL/Util.cs
@@ -225,8 +225,6 @@ namespace JSIL.Internal {
 
         public static string EscapeCharacter (char character, bool forJson) {
             switch (character) {
-                case '\0':
-                    return @"\0";
                 case '\'':
                     return @"\'";
                 case '\\':

--- a/Tests/SimpleTestCases/StringEscape_Issue687.cs
+++ b/Tests/SimpleTestCases/StringEscape_Issue687.cs
@@ -1,0 +1,14 @@
+using System;
+
+public static class Program
+{
+    public static void Main(string[] args)
+    {
+        var str = "\01";
+        Console.WriteLine(str.Length);
+
+        Console.WriteLine(str[0] == (char)0 ? "true" : "false");
+        Console.WriteLine(str[1] == '1' ? "true" : "false");
+    }
+
+}

--- a/Tests/SimpleTests.csproj
+++ b/Tests/SimpleTests.csproj
@@ -101,6 +101,7 @@
     <None Include="SimpleTestCases\Issue651.cs" />
     <Compile Include="SimpleTestCases\ReflectionGenericMethodInvoke.cs" />
     <Compile Include="ExpressionTests.cs" />
+    <None Include="SimpleTestCases\StringEscape_Issue687.cs" />
     <Compile Include="SimpleTests.cs" />
     <None Include="SimpleTestCases\BaseAutoProperties.cs" />
     <None Include="SimpleTestCases\OverloadedVirtualMethods.cs" />


### PR DESCRIPTION
Fixed #687.