### PR TITLE
Delegate update

### DIFF
--- a/Libraries/JSIL.Bootstrap.js
+++ b/Libraries/JSIL.Bootstrap.js
@@ -462,26 +462,8 @@ JSIL.ImplementExternals("System.Delegate", function ($) {
       }
       if (!this.__isMethodInfoResolved__) {
         var methodInfo = this.__methodInfoResolver__();
-        if (methodInfo.get_DeclaringType().get_IsInterface()) {
-          // TODO: find better solution for resolving MethodInfo in class by interface MethodInfo.
-          // TODO: this will not work for interface generic methods.
-          methodInfo = null;
-          var allMethods = JSIL.GetMembersInternal(
-            this.__object__.__ThisType__, 
-            $jsilcore.BindingFlags.$Flags("DeclaredOnly", "Public", "NonPublic", "Instance"),
-            "$AllMethods");
-          for (var i=0; i < allMethods.length; i++) {
-            var impl = JSIL.$GetMethodImplementation(allMethods[i], this.__object__);
-            if (impl === this.__method__) {
-              methodInfo = allMethods[i];
-              break;
-            }
-          }
-          
-          if (methodInfo === null) {
-            throw new Error("Method info not found");
-          }          
-        }
+        // TODO: find better solution for resolving MethodInfo in class by MethodInfo in base class.
+        // Currently it will not find proper derived implementation MethodInfo for virtual method and interface methods.
         JSIL.SetValueProperty(this, "__methodInfo__", methodInfo);
         this.__isMethodInfoResolved__ = true;
       }

--- a/Libraries/JSIL.Core.js
+++ b/Libraries/JSIL.Core.js
@@ -10061,8 +10061,10 @@ JSIL.$GetMethodImplementation = function (method, target) {
       if (!result.signature.IsClosed)
         JSIL.RuntimeError("Generic method is not closed");
   }
-
+  
+  // 1. Generic
   if (genericArgumentValues && genericArgumentValues.length) {
+    // 1.1 Generic static
     if (isStatic) {
       // Return an invoker that concats generic arguments and arglist and invokes
       //  static generic method implementation directly.
@@ -10074,7 +10076,7 @@ JSIL.$GetMethodImplementation = function (method, target) {
           publicInterface, fullArgumentList
         );
       };
-
+    // 1.2 Generic instance (interface)
     } else if (result instanceof JSIL.InterfaceMethod) {
       // Return an invoker that specifies the generic arguments and passes in rest
 
@@ -10085,7 +10087,7 @@ JSIL.$GetMethodImplementation = function (method, target) {
           methodArgs
         );
       };
-
+    // 1.3 Generic instance (non-interface)
     } else {
       // Return an invoker that concats generic arguments and arglist and invokes
       //  generic method implementation directly.
@@ -10098,7 +10100,8 @@ JSIL.$GetMethodImplementation = function (method, target) {
         );
       };
     }
-
+  // 2. Non-generic
+  // 2.1 Non-generic instance (interface)
   } else if (result instanceof JSIL.InterfaceMethod) {
     // Wrap the interface method invoker since it expects a generic arguments parameter.
 
@@ -10111,6 +10114,8 @@ JSIL.$GetMethodImplementation = function (method, target) {
   if (!result) {
     debugger;
   }
+  // 2.2 Non-generic instance (non-interface)
+  // 2.3 Non-generic static
   return result;
 };
 

--- a/Tests/FailingTestCases/DelegateMethod_Issue604.cs
+++ b/Tests/FailingTestCases/DelegateMethod_Issue604.cs
@@ -5,12 +5,7 @@ public static class Program
 {
     public static void Main()
     {
-        Test(new Test());
-        //TestInterface(new Test());
-
-        Action a = M1;
-        a += M2;
-        WriteAction(a);
+        TestInterface(new Test());
     }
 
     public static void TestInterface(ITest<object> item)
@@ -26,19 +21,6 @@ public static class Program
         WriteAction((Action)Delegate.CreateDelegate(typeof(Action), item, typeof(ITest<object>).GetMethod("GenericMethod2").MakeGenericMethod(typeof(string))));
     }
 
-    public static void Test(Test item)
-    {
-        WriteAction(item.Method1);
-        WriteAction(item.Method2);
-        WriteAction(item.GenericMethod1<int>);
-        WriteAction(item.GenericMethod2<string>);
-
-        WriteAction((Action)Delegate.CreateDelegate(typeof(Action), item, typeof(Test).GetMethod("Method1")));
-        WriteAction((Action)Delegate.CreateDelegate(typeof(Action), item, typeof(Test).GetMethod("Method2")));
-        WriteAction((Action)Delegate.CreateDelegate(typeof(Action), item, typeof(Test).GetMethod("GenericMethod1").MakeGenericMethod(typeof(string))));
-        WriteAction((Action)Delegate.CreateDelegate(typeof(Action), item, typeof(Test).GetMethod("GenericMethod2").MakeGenericMethod(typeof(string))));
-    }
-
     public static void WriteAction(Action action)
     {
         Console.Write(action.Method.DeclaringType.Name);
@@ -51,16 +33,6 @@ public static class Program
         Console.Write(".");
         Console.WriteLine(mi.Name);
         Console.WriteLine(mi.ContainsGenericParameters ? "true" : "false");
-    }
-
-    public static void M1()
-    {
-
-    }
-
-    public static void M2()
-    {
-
     }
 }
 

--- a/Tests/SimpleTestCases/DelegateDetached_Issue624.cs
+++ b/Tests/SimpleTestCases/DelegateDetached_Issue624.cs
@@ -1,0 +1,441 @@
+using System;
+using System.Runtime.InteropServices;
+
+public static class Program
+{
+    public static void Main()
+    {
+        var d =
+            (Action<NonGenericClass, string>)
+                Delegate.CreateDelegate(typeof(Action<NonGenericClass, string>), null,
+                    typeof(NonGenericClass).GetMethod("Run"));
+        d(new NonGenericClass(1), "in");
+        d(null, "in");
+
+        var d2 =
+            (Action<NonGenericClass, string>)
+                Delegate.CreateDelegate(typeof(Action<NonGenericClass, string>), null,
+                    typeof(NonGenericClass).GetMethod("RunGeneric").MakeGenericMethod(typeof(string)));
+        d2(new NonGenericClass(1), "in");
+        d2(null, "in");
+
+        var d3 =
+            (Action<GenericClass<string>, string>)
+                Delegate.CreateDelegate(typeof(Action<GenericClass<string>, string>), null,
+                    typeof(GenericClass<string>).GetMethod("Run"));
+        d3(new GenericClass<string>(1), "in");
+        d3(null, "in");
+
+        var d4 =
+            (Action<GenericClass<string>, string, string>)
+                Delegate.CreateDelegate(typeof(Action<GenericClass<string>, string, string>), null,
+                    typeof(GenericClass<string>).GetMethod("RunGeneric").MakeGenericMethod(typeof(string)));
+        d4(new GenericClass<string>(1), "in", "in2");
+        d4(null, "in", "in2");
+
+        var d5 =
+            (Func<NonGenericClass, string, string>)
+                Delegate.CreateDelegate(typeof(Func<NonGenericClass, string, string>), null,
+                    typeof(NonGenericClass).GetMethod("RunOutput"));
+        Console.WriteLine(d5(new NonGenericClass(1), "in"));
+        Console.WriteLine(d5(null, "in"));
+
+        var d6 =
+            (Func<NonGenericClass, string, string>)
+                Delegate.CreateDelegate(typeof(Func<NonGenericClass, string, string>), null,
+                    typeof(NonGenericClass).GetMethod("RunOutputGeneric").MakeGenericMethod(typeof(string)));
+        Console.WriteLine(d6(new NonGenericClass(1), "in"));
+        Console.WriteLine(d6(null, "in"));
+
+        var d7 =
+            (Func<GenericClass<string>, string, string>)
+                Delegate.CreateDelegate(typeof(Func<GenericClass<string>, string, string>), null,
+                    typeof(GenericClass<string>).GetMethod("RunOutput"));
+        Console.WriteLine(d7(new GenericClass<string>(1), "in"));
+        Console.WriteLine(d7(null, "in"));
+
+        var d8 =
+            (Func<GenericClass<string>, string, string, string>)
+                Delegate.CreateDelegate(typeof(Func<GenericClass<string>, string, string, string>), null,
+                    typeof(GenericClass<string>).GetMethod("RunOutputGeneric").MakeGenericMethod(typeof(string)));
+        Console.WriteLine(d8(new GenericClass<string>(1), "in", "in2"));
+        Console.WriteLine(d8(null, "in", "in2"));
+
+        var d9 =
+    (Action<IInterface, string>)
+        Delegate.CreateDelegate(typeof(Action<IInterface, string>), null,
+            typeof(IInterface).GetMethod("Run"));
+        d9(new NonGenericClassImplementor(1), "in");
+        d9(new GenericClassImplementor<string>(2), "in");
+
+        //Looks like .Net doesn't support unbinded delegate for generic interface methods.
+        /*var d10 =
+    (Action<IInterface, string>)
+        Delegate.CreateDelegate(typeof(Action<IInterface, string>), null,
+            typeof(IInterface).GetMethod("RunGeneric").MakeGenericMethod(typeof(string)));
+        d10(new NonGenericClassImplementor(1), "in");
+        d10(new GenericClassImplementor<string>(2), "in");*/
+
+
+        var d11 =
+    (Action<IGenericInterface<string>, string>)
+        Delegate.CreateDelegate(typeof(Action<IGenericInterface<string>, string>), null,
+            typeof(IGenericInterface<string>).GetMethod("Run"));
+        d11(new NonGenericClassImplementor(1), "in");
+        d11(new GenericClassImplementor<string>(2), "in");
+
+        /*var d12 =
+            (Action<IGenericInterface<string>, string, string>)
+                Delegate.CreateDelegate(typeof(Action<IGenericInterface<string>, string, string>), null,
+                    typeof(IGenericInterface<string>).GetMethod("RunGeneric2").MakeGenericMethod(typeof(string)));
+        d12(new NonGenericClassImplementor(1), "in", "in2");
+        d12(new GenericClassImplementor<string>(2), "in", "in2");*/
+
+        var d12 =
+    (Func<IInterface, string, string>)
+        Delegate.CreateDelegate(typeof(Func<IInterface, string, string>), null,
+            typeof(IInterface).GetMethod("RunOutput"));
+        Console.WriteLine(d12(new NonGenericClassImplementor(1), "in"));
+        Console.WriteLine(d12(new GenericClassImplementor<string>(2), "in"));
+
+        /*var d13 =
+            (Func<IInterface, string, string>)
+                Delegate.CreateDelegate(typeof(Func<IInterface, string, string>), null,
+                    typeof(IInterface).GetMethod("RunOutputGeneric").MakeGenericMethod(typeof(string)));
+        Console.WriteLine(d13(new NonGenericClassImplementor(1), "in"));
+        Console.WriteLine(d13(new GenericClassImplementor<string>(2), "in"));*/
+
+        var d14 =
+            (Func<IGenericInterface<string>, string, string>)
+                Delegate.CreateDelegate(typeof(Func<IGenericInterface<string>, string, string>), null,
+                    typeof(IGenericInterface<string>).GetMethod("RunOutput"));
+        Console.WriteLine(d14(new NonGenericClassImplementor(1), "in"));
+        Console.WriteLine(d14(new GenericClassImplementor<string>(2), "in"));
+
+        /*var d15 =
+            (Func<IGenericInterface<string>, string, string, string>)
+                Delegate.CreateDelegate(typeof(Func<IGenericInterface<string>, string, string, string>), null,
+                    typeof(IGenericInterface<string>).GetMethod("RunOutputGeneric2").MakeGenericMethod(typeof(string)));
+        Console.WriteLine(d15(new NonGenericClassImplementor(1), "in", "in2"));
+        Console.WriteLine(d15(new GenericClassImplementor<string>(2), "in", "in2"));*/
+    }
+}
+
+
+public class NonGenericClass
+{
+    public int _value;
+
+    public NonGenericClass(int value)
+    {
+        _value = value;
+    }
+
+    public void Run(string input)
+    {
+        if (this != null)
+        {
+            Console.WriteLine("Non-Generic class, Non-Generic, this: " + _value + "; Input: " + input);
+        }
+        else
+        {
+            Console.WriteLine("Non-Generic class, Non-Generic, this==null; Input: " + input);
+        }
+    }
+
+    public void RunGeneric<T>(T input)
+    {
+        if (this != null)
+        {
+            Console.WriteLine("Non-Generic class, Generic, this: " + _value + "; Input: " + input);
+        }
+        else
+        {
+            Console.WriteLine("Non-Generic class, Generic, this==null " + input);
+        }
+    }
+
+    public string RunOutput(string input)
+    {
+        if (this != null)
+        {
+            Console.WriteLine("Non-Generic class, Non-Generic, this: " + _value + "; Input: " + input);
+        }
+        else
+        {
+            Console.WriteLine("Non-Generic class, Non-Generic, this==null; Input: " + input);
+        }
+
+        return "output1";
+    }
+
+    public string RunOutputGeneric<T>(T input)
+    {
+        if (this != null)
+        {
+            Console.WriteLine("Non-Generic class, Generic, this: " + _value + "; Input: " + input);
+        }
+        else
+        {
+            Console.WriteLine("Non-Generic class, Generic, this==null " + input);
+        }
+
+        return "output2";
+    }
+}
+
+public class GenericClass<T>
+{
+    public int _value;
+
+    public GenericClass(int value)
+    {
+        _value = value;
+    }
+
+    public void Run(string input)
+    {
+        if (this != null)
+        {
+            Console.WriteLine("Generic class, Non-Generic, this: " + _value + "; Input: " + input);
+        }
+        else
+        {
+            Console.WriteLine("Generic class, Non-Generic, this==null; Input: " + input);
+        }
+    }
+
+    public void RunGeneric<T2>(T input, T2 input2)
+    {
+        if (this != null)
+        {
+            Console.WriteLine("Generic class, Generic, this: " + _value + "; Input: " + input + "; Input2: " + input2);
+        }
+        else
+        {
+            Console.WriteLine("Generic class, Generic, this==null " + input + "; Input2: " + input2);
+        }
+    }
+
+    public string RunOutput(string input)
+    {
+        if (this != null)
+        {
+            Console.WriteLine("Generic class, Non-Generic, this: " + _value + "; Input: " + input);
+        }
+        else
+        {
+            Console.WriteLine("Generic class, Non-Generic, this==null; Input: " + input);
+        }
+
+        return "output3";
+    }
+
+    public string RunOutputGeneric<T2>(T input, T2 input2)
+    {
+        if (this != null)
+        {
+            Console.WriteLine("Generic class, Generic, this: " + _value + "; Input: " + input + "; Input2: " + input2);
+        }
+        else
+        {
+            Console.WriteLine("Generic class, Generic, this==null " + input + "; Input2: " + input2);
+        }
+
+        return "output4";
+    }
+}
+
+public interface IInterface
+{
+    void Run(string input);
+    void RunGeneric<T>(T input);
+
+    string RunOutput(string input);
+    string RunOutputGeneric<T>(T input);
+}
+
+public interface IGenericInterface<T>
+{
+    void Run(string input);
+    void RunGeneric2<T2>(T input, T2 input2);
+
+    string RunOutput(string input);
+    string RunOutputGeneric2<T2>(T input, T2 input2);
+}
+
+public class NonGenericClassImplementor : IInterface, IGenericInterface<string>
+{
+    public int _value;
+
+    public NonGenericClassImplementor(int value)
+    {
+        _value = value;
+    }
+
+    public void Run(string input)
+    {
+        if (this != null)
+        {
+            Console.WriteLine("Non-Generic class, Non-Generic, this: " + _value + "; Input: " + input);
+        }
+        else
+        {
+            Console.WriteLine("Non-Generic class, Non-Generic, this==null; Input: " + input);
+        }
+    }
+
+    public void RunGeneric<T>(T input)
+    {
+        if (this != null)
+        {
+            Console.WriteLine("Non-Generic class, Generic, this: " + _value + "; Input: " + input);
+        }
+        else
+        {
+            Console.WriteLine("Non-Generic class, Generic, this==null " + input);
+        }
+    }
+
+    public void RunGeneric2<T2>(string input, T2 input2)
+    {
+        if (this != null)
+        {
+            Console.WriteLine("Non-Generic class, Generic, this: " + _value + "; Input: " + input + "; Input2: " + input2);
+        }
+        else
+        {
+            Console.WriteLine("Non-Generic class, Generic, this==null " + input + "; Input2: " + input2);
+        }
+    }
+
+    public string RunOutput(string input)
+    {
+        if (this != null)
+        {
+            Console.WriteLine("Non-Generic class, Non-Generic, this: " + _value + "; Input: " + input);
+        }
+        else
+        {
+            Console.WriteLine("Non-Generic class, Non-Generic, this==null; Input: " + input);
+        }
+
+        return "99";
+    }
+
+    public string RunOutputGeneric<T>(T input)
+    {
+        if (this != null)
+        {
+            Console.WriteLine("Non-Generic class, Generic, this: " + _value + "; Input: " + input);
+        }
+        else
+        {
+            Console.WriteLine("Non-Generic class, Generic, this==null " + input);
+        }
+
+        return "100";
+    }
+
+    public string RunOutputGeneric2<T2>(string input, T2 input2)
+    {
+        if (this != null)
+        {
+            Console.WriteLine("Non-Generic class, Generic, this: " + _value + "; Input: " + input + "; Input2: " + input2);
+        }
+        else
+        {
+            Console.WriteLine("Non-Generic class, Generic, this==null " + input + "; Input2: " + input2);
+        }
+
+        return "101";
+    }
+}
+
+public class GenericClassImplementor<T> : IGenericInterface<T>, IInterface
+{
+    public int _value;
+
+    public GenericClassImplementor(int value)
+    {
+        _value = value;
+    }
+
+    public void Run(string input)
+    {
+        if (this != null)
+        {
+            Console.WriteLine("Generic class, Non-Generic, this: " + _value + "; Input: " + input);
+        }
+        else
+        {
+            Console.WriteLine("Generic class, Non-Generic, this==null; Input: " + input);
+        }
+    }
+
+    public void RunGeneric2<T2>(T input, T2 input2)
+    {
+        if (this != null)
+        {
+            Console.WriteLine("Generic class, Generic, this: " + _value + "; Input: " + input + "; Input2: " + input2);
+        }
+        else
+        {
+            Console.WriteLine("Generic class, Generic, this==null " + input + "; Input2: " + input2);
+        }
+    }
+
+    public void RunGeneric<T>(T input)
+    {
+        if (this != null)
+        {
+            Console.WriteLine("Generic class, Generic, this: " + _value + "; Input: " + input);
+        }
+        else
+        {
+            Console.WriteLine("Generic class, Generic, this==null " + input);
+        }
+    }
+
+    public string RunOutput(string input)
+    {
+        if (this != null)
+        {
+            Console.WriteLine("Generic class, Non-Generic, this: " + _value + "; Input: " + input);
+        }
+        else
+        {
+            Console.WriteLine("Generic class, Non-Generic, this==null; Input: " + input);
+        }
+
+        return "110";
+    }
+
+    public string RunOutputGeneric2<T2>(T input, T2 input2)
+    {
+        if (this != null)
+        {
+            Console.WriteLine("Generic class, Generic, this: " + _value + "; Input: " + input + "; Input2: " + input2);
+        }
+        else
+        {
+            Console.WriteLine("Generic class, Generic, this==null " + input + "; Input2: " + input2);
+        }
+
+        return "111";
+    }
+
+    public string RunOutputGeneric<T>(T input)
+    {
+        if (this != null)
+        {
+            Console.WriteLine("Generic class, Generic, this: " + _value + "; Input: " + input);
+        }
+        else
+        {
+            Console.WriteLine("Generic class, Generic, this==null " + input);
+        }
+
+        return "112";
+    }
+}

--- a/Tests/SimpleTests.csproj
+++ b/Tests/SimpleTests.csproj
@@ -88,6 +88,7 @@
     <None Include="SimpleTestCases\Issue478.cs" />
     <None Include="SimpleTestCases\Issue560.cs" />
     <None Include="SimpleTestCases\Issue491.cs" />
+    <None Include="SimpleTestCases\DelegateDetached_Issue624.cs" />
     <None Include="SimpleTestCases\Issue491_2.cs" />
     <None Include="SimpleTestCases\Issue491_3.cs" />
     <None Include="SimpleTestCases\Issue682.cs" />

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -266,6 +266,7 @@
     <None Include="SpecialTestCases\TranslateTypeInStubbedAssembly.cs" />
     <None Include="SpecialTestCases\TranslateMethodInStubbedAssembly.cs" />
     <None Include="SpecialTestCases\TranslateMethodInStubbedType.cs" />
+    <None Include="FailingTestCases\DelegateMethod_Issue604.cs" />
     <Compile Include="TypeInformationTests.cs" />
     <None Include="TestCases\LongArithmetic.cs" />
     <None Include="InterfaceTestCases\NestedInterfaces.cs" />


### PR DESCRIPTION
Two updates for delegate:
1. Support unbind form of delegate to instance method (so that we can pass instance as first argument).
2. Disabled guess of proper MethodInfo for interface delegate, as it works only in some conditions. We need to find beter solution here (we need some way to find method info in implementation based on methodinfo in declaration and implementation type). This logic should be written similar to the logic, that select correct method on call - but we need discuss how to reuse already existing code or refactor it for reuse.

This change need for interpreting some more complex expressions.