### PR TITLE
Expression engine requirments

### DIFF
--- a/Libraries/JSIL.Bootstrap.Linq.js
+++ b/Libraries/JSIL.Bootstrap.Linq.js
@@ -668,14 +668,6 @@ JSIL.ImplementExternals("System.Linq.Expressions.Expression", function ($) {
       return System.Linq.Expressions.ParameterExpression.Make(type, name, type.IsByRef);
     }
   );
-
-  $.Method({Static:true , Public:true }, "Equal", 
-    new JSIL.MethodSignature($jsilcore.TypeRef("System.Linq.Expressions.BinaryExpression"), [$jsilcore.TypeRef("System.Linq.Expressions.Expression"), $jsilcore.TypeRef("System.Linq.Expressions.Expression")], []), 
-    function Equal (left, right) {
-      // FIXME
-      return null;
-    }
-  )
 });
 
 JSIL.MakeClass($jsilcore.TypeRef("System.Linq.Expressions.Expression"), "System.Linq.Expressions.ConstantExpression", true, [], function ($) {

--- a/Libraries/JSIL.Bootstrap.Linq.js
+++ b/Libraries/JSIL.Bootstrap.Linq.js
@@ -686,6 +686,10 @@ JSIL.MakeClass($jsilcore.TypeRef("System.Linq.Expressions.Expression"), "System.
   );
 });
 
+JSIL.MakeClass($jsilcore.TypeRef("System.Linq.Expressions.ConstantExpression"), "System.Linq.Expressions.TypedConstantExpression", true, [], function ($) {
+  var $thisType = $.publicInterface;
+});
+
 JSIL.ImplementExternals("System.Linq.Expressions.ConstantExpression", function ($) {
   $.Method({Static:false, Public:false}, ".ctor", 
     (new JSIL.MethodSignature(null, [$.Object], [])), 
@@ -697,10 +701,30 @@ JSIL.ImplementExternals("System.Linq.Expressions.ConstantExpression", function (
   $.Method({Static:true , Public:false}, "Make", 
     (new JSIL.MethodSignature($jsilcore.TypeRef("System.Linq.Expressions.ConstantExpression"), [$.Object, $jsilcore.TypeRef("System.Type")], [])), 
     function Make (value, type) {
-      return new System.Linq.Expressions.ConstantExpression(value);
+      if (value == null && type == $jsilcore.System.Object.__Type__ || value != null && JSIL.GetType(value) == type) {
+        return new System.Linq.Expressions.ConstantExpression(value);
+      } else {
+        return new System.Linq.Expressions.TypedConstantExpression(value, type);
+      }
+    }
+  );
+});
+
+JSIL.ImplementExternals("System.Linq.Expressions.TypedConstantExpression", function ($) {
+  $.Method({Static:false, Public:false}, ".ctor", 
+    (new JSIL.MethodSignature(null, [$.Object, $jsilcore.TypeRef("System.Type")], [])), 
+    function _ctor (value, type) {
+      this._value = value;
+      this._type = type;
     }
   );
 
+  $.Method({Static:false , Public:true}, "get_Type", 
+    new JSIL.MethodSignature($jsilcore.TypeRef("System.Type"), [], []), 
+    function get_Type() {
+      return this._type;
+    }
+  );
 });
 
 JSIL.MakeClass($jsilcore.TypeRef("System.Linq.Expressions.Expression"), "System.Linq.Expressions.ParameterExpression", true, [], function ($) {

--- a/Libraries/JSIL.Bootstrap.js
+++ b/Libraries/JSIL.Bootstrap.js
@@ -1983,6 +1983,33 @@ JSIL.MakeStaticClass("System.Threading.Interlocked", true, [], function ($) {
   $.ExternalMethod({Public: true , Static: true }, "CompareExchange", 
     new JSIL.MethodSignature("!!0", [JSIL.Reference.Of("!!0"), "!!0", "!!0"], ["T"])
   );
+  $.ExternalMethod({Public: true , Static: true }, "CompareExchange", 
+    new JSIL.MethodSignature($.Object, [JSIL.Reference.Of($.Object), $.Object, $.Object], [])
+  );
+});
+
+JSIL.ImplementExternals("System.Threading.Interlocked", function ($) {
+  $.Method({Public: true , Static: true }, "CompareExchange", 
+    new JSIL.MethodSignature("!!0", [JSIL.Reference.Of("!!0"), "!!0", "!!0"], ["T"]),
+    function CompareExchange$b1 (T, /* ref */ location1, value, comparand) {
+      var result = JSIL.CloneParameter(T, location1.get());
+      if (JSIL.ObjectEquals(location1.get(), comparand)) {
+        location1.set(JSIL.CloneParameter(T, value));
+      }
+      return result;
+    }
+  );
+
+  $.Method({Public: true , Static: true }, "CompareExchange", 
+    new JSIL.MethodSignature($.Object, [JSIL.Reference.Of($.Object), $.Object, $.Object], []),
+    function CompareExchange (/* ref */ location1, value, comparand) {
+      var result = location1.get();
+      if (JSIL.ObjectEquals(location1.get(), comparand)) {
+        location1.set(value);
+      }
+      return result;
+    }
+  );  
 });
 
 JSIL.MakeStaticClass("System.Threading.Volatile", true, [], function ($) {

--- a/Libraries/JSIL.Core.Reflection.js
+++ b/Libraries/JSIL.Core.Reflection.js
@@ -829,6 +829,27 @@ JSIL.ImplementExternals("System.Reflection.PropertyInfo", function ($) {
       return getSetMethodImpl.call(this, true) !== null;
     }
   );
+  
+  var equalsImpl = function (lhs, rhs) {
+    if (lhs === rhs)
+      return true;
+
+    return JSIL.ObjectEquals(lhs, rhs);
+  };
+
+  $.Method({Static:true , Public:true }, "op_Equality", 
+    (new JSIL.MethodSignature($.Boolean, [$jsilcore.TypeRef("System.Reflection.PropertyInfo"), $jsilcore.TypeRef("System.Reflection.PropertyInfo")], [])), 
+    function op_Equality (left, right) {
+      return equalsImpl(left, right);
+    }
+  );
+
+  $.Method({Static:true , Public:true }, "op_Inequality", 
+    (new JSIL.MethodSignature($.Boolean, [$jsilcore.TypeRef("System.Reflection.PropertyInfo"), $jsilcore.TypeRef("System.Reflection.PropertyInfo")], [])), 
+    function op_Inequality (left, right) {
+      return !equalsImpl(left, right);
+    }
+  );
 });
 
 $jsilcore.$MethodGetParameters = function (method) {
@@ -1045,6 +1066,34 @@ JSIL.ImplementExternals(
         }
 
         return obj[this._descriptor.Name];
+      }
+    );
+    
+    var equalsImpl = function (lhs, rhs) {
+      if (lhs === rhs)
+        return true;
+
+      return JSIL.ObjectEquals(lhs, rhs);
+    };
+
+    $.Method({Static:true , Public:true }, "op_Equality", 
+      (new JSIL.MethodSignature($.Boolean, [$jsilcore.TypeRef("System.Reflection.FieldInfo"), $jsilcore.TypeRef("System.Reflection.FieldInfo")], [])), 
+      function op_Equality (left, right) {
+        return equalsImpl(left, right);
+      }
+    );
+
+    $.Method({Static:true , Public:true }, "op_Inequality", 
+      (new JSIL.MethodSignature($.Boolean, [$jsilcore.TypeRef("System.Reflection.FieldInfo"), $jsilcore.TypeRef("System.Reflection.FieldInfo")], [])), 
+      function op_Inequality (left, right) {
+        return !equalsImpl(left, right);
+      }
+    );
+    
+    $.Method({Static:false , Public:true }, "get_IsLiteral", 
+      (new JSIL.MethodSignature($.Boolean, [], [])), 
+      function get_IsLiteral () {
+        return false;
       }
     );
 

--- a/Libraries/JSIL.Core.Reflection.js
+++ b/Libraries/JSIL.Core.Reflection.js
@@ -250,6 +250,16 @@ JSIL.ImplementExternals(
         return getMethodImpl(this, name, defaultFlags(), argumentTypes);
       }
     );
+    
+    $.Method({Public: true , Static: false}, "GetMethod",
+      new JSIL.MethodSignature($jsilcore.TypeRef("System.Reflection.MethodInfo"), [$.String, $jsilcore.TypeRef("System.Reflection.BindingFlags"), $jsilcore.TypeRef("System.Reflection.Binder"), typeArray, $jsilcore.TypeRef("System.Array", ["System.Reflection.ParameterModifier"])]),      
+      function (name, flags, binder, argumentTypes, modifiers) {
+        if (binder !== null || modifiers !== null) {
+          throw new System.NotImplementedException("Binder and ParameterModifier are not supported yet.");
+        }
+        return getMethodImpl(this, name, flags, argumentTypes);
+      }
+    );
 
     $.Method({Public: true , Static: false}, "GetMethods",
       new JSIL.MethodSignature(methodArray, []),      

--- a/Proxies/BCL/JSIL.Bootstrap.Linq.cs
+++ b/Proxies/BCL/JSIL.Bootstrap.Linq.cs
@@ -183,12 +183,6 @@ namespace JSIL.Proxies.Bcl
         {
             throw new NotImplementedException();
         }
-
-        [JSExternal]
-        public static BinaryExpression Equal(Expression left, Expression right)
-        {
-            throw new NotImplementedException();
-        }
     }
 
     [JSProxy(typeof(ConstantExpression), JSProxyMemberPolicy.ReplaceNone, JSProxyAttributePolicy.ReplaceDeclared, JSProxyInterfacePolicy.ReplaceNone, false)]

--- a/Tests/SimpleTestCases/Issue205.cs
+++ b/Tests/SimpleTestCases/Issue205.cs
@@ -1,8 +1,0 @@
-﻿using System;
-using System.Linq.Expressions;
-
-public static class Program {
-    public static void Main (string[] args) {
-        Expression<Func<int, bool>> expr = (value) => value == 42;
-    }
-}

--- a/Tests/SimpleTestCasesForTranslatedBcl/ExpressionsTest.cs
+++ b/Tests/SimpleTestCasesForTranslatedBcl/ExpressionsTest.cs
@@ -8,6 +8,8 @@ public static class Program
 
     public static void Main(string[] args)
     {
+        Expression<Func<int, bool>> expr = (value) => value == 42;
+
         WriteMethod(() => StaticMethodNonGeneric());
         WriteMethod(() => StaticMethodGeneric<A>());
 

--- a/Tests/SimpleTests.csproj
+++ b/Tests/SimpleTests.csproj
@@ -128,7 +128,6 @@
     <None Include="SimpleTestCases\StructPassedToGeneric_Issue494_1.cs" />
     <None Include="SimpleTestCases\StructPassedToGeneric_Issue494_2.cs" />
     <None Include="SimpleTestCases\RefDouble.cs" />
-    <None Include="SimpleTestCases\Issue205.cs" />
     <None Include="SimpleTestCases\NullableStructRef.cs" />
     <None Include="SimpleTestCases\ConvertObject.cs" />
     <None Include="SimpleTestCases\EnumBaseType.cs" />


### PR DESCRIPTION
Here is some staff, that I've found we need for correct work of Expressions. I have not added test for all this small changes, but will add some more complex Expressions test after this, #616 and some my future PR will be merged.

Changes here:
TypedConstantExpression simple implementation added.
op_Equality/op_Inequality for PropertyInfo and FieldInfo added.
Stub for Expression.Equal removed (as it just returned null) - we will use translated BCL version
Type.GetMethod additional overload added.
Interlocked.CompareExchange implementation added.

Probably we need add separate test for Interlocked.CompareExchange. If you merge it, lets create issue for it.