### PR TITLE
Equality between null emscripten pointer and IntPtr.Zero

### DIFF
--- a/Libraries/JSIL.Unsafe.js
+++ b/Libraries/JSIL.Unsafe.js
@@ -52,8 +52,18 @@ JSIL.ImplementExternals("System.IntPtr", function ($) {
   $.Method({Static:true , Public:true }, "op_Equality", 
     (new JSIL.MethodSignature($.Boolean, [tIntPtr, tIntPtr], [])), 
     function op_Equality (lhs, rhs) {
+      function isNullPointer(p) {
+        return (lhs.pointer === null && lhs.value == 0) ||
+               (lhs.pointer !== null && lhs.pointer.offsetInBytes == 0)
+      }
+
+      // Null pointers always equal, regardless of where they came from      
+      if (isNullPointer(lhs) && isNullPointer(rhs)) {
+        return true;
+      }
+
       if (lhs.pointer !== null) {
-        if (!rhs.pointer)
+        if (!rhs.pointer) // Non-null emscripten pointers can't equal C# ones
           return false;
 
         return rhs.pointer.equals(lhs.pointer);
@@ -66,6 +76,15 @@ JSIL.ImplementExternals("System.IntPtr", function ($) {
   $.Method({Static:true , Public:true }, "op_Inequality", 
     (new JSIL.MethodSignature($.Boolean, [tIntPtr, tIntPtr], [])), 
     function op_Inequality (lhs, rhs) {
+      function isNullPointer(p) {
+        return (lhs.pointer === null && lhs.value == 0) ||
+               (lhs.pointer !== null && lhs.pointer.offsetInBytes == 0)
+      }
+
+      if (isNullPointer(lhs) && isNullPointer(rhs)) {
+        return false;
+      }
+
       if (lhs.pointer !== null) {
         if (!rhs.pointer)
           return true;

--- a/Tests/EmscriptenTestCases/IntPtrZeroEquality.cs
+++ b/Tests/EmscriptenTestCases/IntPtrZeroEquality.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Text;
+using JSIL.Runtime;
+
+using System.Runtime.InteropServices;
+
+public static unsafe class Program {
+    [DllImport("common.dll", CallingConvention=CallingConvention.Cdecl)]
+    public static extern IntPtr ReturnNullPtr ();
+
+    public static void Main () {
+        if (ReturnNullPtr() == IntPtr.Zero) {
+            Console.WriteLine("null pointers equal");
+        } else {
+            Console.WriteLine("null pointers are not equal");
+        }
+    }
+}

--- a/Tests/EmscriptenTestCases/common/common.cpp
+++ b/Tests/EmscriptenTestCases/common/common.cpp
@@ -101,6 +101,10 @@ export(void)Free(void * ptr) {
     return free(ptr);
 }
 
+export(void *) ReturnNullPtr() {
+	return NULL;
+}
+
 export(float) AddFloat (float a, float b) {
 	return a + b;
 }

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -146,6 +146,7 @@
     <None Include="EmscriptenTestCases\StaticStringFromIntPtr.cs" />
     <None Include="EmscriptenTestCases\OutStructArrayParameter.cs" />
     <Compile Include="EmscriptenTestCases\ProxiedExternFunction.cs" />
+    <None Include="EmscriptenTestCases\IntPtrZeroEquality.cs" />
     <Compile Include="EmscriptenTests.cs" />
     <Compile Include="CodeProviders.cs">
       <SubType>Component</SubType>


### PR DESCRIPTION
This bug causes FNA to incorrectly believe the platform supports
more opengl functions than it actually does, because it can't
tell that the returned function pointers are null.