### PR TITLE
ReadOnlyCollection creation with IList<T>. Test added.

### DIFF
--- a/Libraries/JSIL.Bootstrap.js
+++ b/Libraries/JSIL.Bootstrap.js
@@ -1629,7 +1629,7 @@ $jsilcore.$ReadOnlyCollectionExternals = function ($) {
   var IListCtor = function (list) {
     this._list = list;
 
-    if (JSIL.IsArray(list._array)) {
+    if (JSIL.IsArray(list._array)) {     
       Object.defineProperty(this, "_items", {
         get: function () {
           return list._array;
@@ -1641,10 +1641,7 @@ $jsilcore.$ReadOnlyCollectionExternals = function ($) {
           return list._array.length;
         }
       });
-    } else {
-      if (!list._items || (typeof(list._size) !== "number"))
-        JSIL.RuntimeError("argument must be a list");
-
+    } else if (list._items && (typeof(list._size) !== "number")) {
       Object.defineProperty(this, "_items", {
         get: function () {
           return list._items;
@@ -1656,7 +1653,20 @@ $jsilcore.$ReadOnlyCollectionExternals = function ($) {
           return list._size;
         }
       });
-    }
+    } else {
+      var array = JSIL.EnumerableToArray(list, this.T);
+      Object.defineProperty(this, "_items", {
+        get: function () {
+          return array;
+        }
+      });
+
+      Object.defineProperty(this, "_size", {
+        get: function () {
+          return array.length;
+        }
+      });
+    } 
   };
 
   $.RawMethod(false, "$listCtor", IListCtor);

--- a/Tests/SimpleTestCases/ReadOnlyCollectionCreation.cs
+++ b/Tests/SimpleTestCases/ReadOnlyCollectionCreation.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+public static class Program
+{
+    public static void Main(string[] args)
+    {
+        var readOnlyCollection = new ReadOnlyCollection<int>(new CustomList());
+
+        foreach (var i in readOnlyCollection)
+        {
+            Console.WriteLine(i);
+        }
+    }
+}
+
+public class CustomList : IList<int>
+{
+    private int[] _content = new[] {1, 2, 5, 10};
+
+    public IEnumerator<int> GetEnumerator()
+    {
+        foreach (var i in _content)
+        {
+            yield return i;
+        }
+    }
+
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+        return GetEnumerator();
+    }
+
+    public void Add(int item)
+    {
+        throw new NotImplementedException();
+    }
+
+    public void Clear()
+    {
+        throw new NotImplementedException();
+    }
+
+    public bool Contains(int item)
+    {
+        throw new NotImplementedException();
+    }
+
+    public void CopyTo(int[] array, int arrayIndex)
+    {
+        throw new NotImplementedException();
+    }
+
+    public bool Remove(int item)
+    {
+        throw new NotImplementedException();
+    }
+
+    public int Count
+    {
+        get { return _content.Length; }
+    }
+
+    public bool IsReadOnly
+    {
+        get { return true; }
+    }
+
+    public int IndexOf(int item)
+    {
+        throw new NotImplementedException();
+    }
+
+    public void Insert(int index, int item)
+    {
+        throw new NotImplementedException();
+    }
+
+    public void RemoveAt(int index)
+    {
+        throw new NotImplementedException();
+    }
+
+    public int this[int index]
+    {
+        get { return _content[index]; }
+        set { throw new NotImplementedException(); }
+    }
+}
+

--- a/Tests/SimpleTests.csproj
+++ b/Tests/SimpleTests.csproj
@@ -106,6 +106,7 @@
     <Compile Include="ExpressionTests.cs" />
     <None Include="SimpleTestCases\StringEscape_Issue687.cs" />
     <None Include="SimpleTestCases\Issue672_2.cs" />
+    <Compile Include="SimpleTestCases\ReadOnlyCollectionCreation.cs" />
     <Compile Include="SimpleTests.cs" />
     <None Include="SimpleTestCases\BaseAutoProperties.cs" />
     <None Include="SimpleTestCases\OverloadedVirtualMethods.cs" />


### PR DESCRIPTION
Previous implementation of ReadOnlyCollection constructor suppose that input is array or List<T> - so custom IList<T> implementation doesn't work.
It is fixed here (I've not created separate issue for it). This fix is last necessary fix for Expresssion Interpreter correct work.