### PR TITLE
Failed to extract BoxedVariable before return result

### DIFF
--- a/JSIL/AST/JSExpressionTypes.cs
+++ b/JSIL/AST/JSExpressionTypes.cs
@@ -2305,6 +2305,7 @@ namespace JSIL.Ast {
         public static JSExpression New (JSExpression inner, TypeReference newType, TypeSystem typeSystem) {
             var cte = inner as JSChangeTypeExpression;
             var literal = inner as JSIntegerLiteral;
+            var variable = inner as JSVariable;
             JSChangeTypeExpression result;
 
             if (cte != null) {
@@ -2318,9 +2319,14 @@ namespace JSIL.Ast {
             var innerType = inner.GetActualType(typeSystem);
             if (TypeUtil.TypesAreEqual(newType, innerType))
                 return inner;
+            else if ((variable != null) && innerType.IsByReference &&
+                     TypeUtil.TypesAreEqual(((ByReferenceType) innerType).ElementType, newType)) {
+                return new JSReadThroughReferenceExpression(variable);
+            }
             else if ((literal != null) && TypeUtil.IsPointer(newType)) {
                 return new JSPointerLiteral(literal.Value, newType);
-            } else
+            }
+            else
                 return result;
         }
 

--- a/Tests/SimpleTestCases/Issue705.cs
+++ b/Tests/SimpleTestCases/Issue705.cs
@@ -1,0 +1,46 @@
+using System;
+
+public static class Program {
+    public static void Main(string[] args) {
+        Resolver.GetResult().RunMe();
+    }
+}
+
+public static class Resolver
+{
+    private static object _syncRoot = new object();
+
+    internal static ResultClass GetResult()
+    {
+        lock (_syncRoot)
+        {
+            ResultClass factory;
+            if (!TryGet(out factory))
+            {
+                factory = Create();
+            }
+
+            return factory;
+        }
+    }
+
+    private static ResultClass Create()
+    {
+        return new ResultClass();
+    }
+
+    private static bool TryGet(out ResultClass result)
+    {
+        result = null;
+        return false;
+    }
+}
+
+public class ResultClass
+{
+    public void RunMe()
+    {
+        Console.WriteLine("Hura!");
+    }
+}
+

--- a/Tests/SimpleTests.csproj
+++ b/Tests/SimpleTests.csproj
@@ -107,6 +107,7 @@
     <Compile Include="ExpressionTests.cs" />
     <None Include="SimpleTestCases\StringEscape_Issue687.cs" />
     <None Include="SimpleTestCases\Issue672_2.cs" />
+    <None Include="SimpleTestCases\Issue705.cs" />
     <Compile Include="SimpleTests.cs" />
     <None Include="SimpleTestCases\BaseAutoProperties.cs" />
     <None Include="SimpleTestCases\OverloadedVirtualMethods.cs" />


### PR DESCRIPTION
Fix #705. Root cause of problem:
C# lock statement use temporary variable inside.
During transformation pass EliminateTemporaries, this temporary variable removed inside `EliminateSingleUseTemporaries.EliminateVariable` with next code:
```
var replacer = new VariableEliminator(
                    variable,
                    JSChangeTypeExpression.New(replaceWith, variable.GetActualType(TypeSystem), TypeSystem)
                );
```
Than, nobody replace JSChangeTypeExpression with any other expression and `JavascriptAstEmitter` simple write inner expression, ignoring type changing:
```
public void VisitNode (JSChangeTypeExpression cte) {
            Visit(cte.Expression);
        }
```

I'm not sure, that I've fixed problem in best place - just added creation of `JSReadThroughReferenceExpression` inside `JSChangeTypeExpression.New` function. Maybe it should be fixed in another way.