### PR TITLE
string.Compare against null.

### DIFF
--- a/Libraries/JSIL.Bootstrap.Text.js
+++ b/Libraries/JSIL.Bootstrap.Text.js
@@ -469,6 +469,13 @@ JSIL.ImplementExternals(
     );
 
     var compareInternal = function (lhs, rhs, comparison) {
+      if (lhs == null && rhs == null)
+        return 0;
+      else if (lhs == null)
+        return -1;
+      else if (rhs == null)
+        return 1;
+        
       switch (comparison.valueOf()) {
         case 1: // System.StringComparison.CurrentCultureIgnoreCase:
         case 3: // System.StringComparison.InvariantCultureIgnoreCase:

--- a/Tests/SimpleTestCases/StringCompare.cs
+++ b/Tests/SimpleTestCases/StringCompare.cs
@@ -19,5 +19,18 @@ public static class Program {
         PrintCompared("Asd", "asdf", StringComparison.OrdinalIgnoreCase);
         PrintCompared("asd", "asdf", StringComparison.Ordinal);
         PrintCompared("asd", "asdf", StringComparison.OrdinalIgnoreCase);
+
+        PrintCompared(null, "asd", StringComparison.Ordinal);
+        PrintCompared("asd", null, StringComparison.Ordinal);
+        PrintCompared(null, "asd", StringComparison.OrdinalIgnoreCase);
+        PrintCompared("asd", null, StringComparison.OrdinalIgnoreCase);
+
+        PrintCompared(null, string.Empty, StringComparison.Ordinal);
+        PrintCompared(string.Empty, null, StringComparison.Ordinal);
+        PrintCompared(null, string.Empty, StringComparison.OrdinalIgnoreCase);
+        PrintCompared(string.Empty, null, StringComparison.OrdinalIgnoreCase);
+
+        PrintCompared(null, null, StringComparison.Ordinal);
+        PrintCompared(null, null, StringComparison.OrdinalIgnoreCase);
     }
 }


### PR DESCRIPTION
Fixed behavior for string.Compare(a, b) if a or b is null. (I haven't created issue for it).