### PR TITLE
Fix some crashes in DeadCodeAnalyzer

### DIFF
--- a/Compiler/Analyzers/DeadCodeAnalyzer/DeadCodeInfoProvider.cs
+++ b/Compiler/Analyzers/DeadCodeAnalyzer/DeadCodeInfoProvider.cs
@@ -178,10 +178,10 @@ namespace JSIL.Compiler.Extensibility.DeadCodeAnalyzer {
                 return;
             }
 
-            AddType(resolvedType.BaseType);
-
             if (types.Add(resolvedType))
             {
+                AddType(resolvedType.BaseType);
+
                 if (resolvedType.HasCustomAttributes)
                 {
                     foreach (CustomAttribute attribute in resolvedType.CustomAttributes)

--- a/Compiler/Analyzers/DeadCodeAnalyzer/DeadCodeInfoProvider.cs
+++ b/Compiler/Analyzers/DeadCodeAnalyzer/DeadCodeInfoProvider.cs
@@ -370,10 +370,8 @@ namespace JSIL.Compiler.Extensibility.DeadCodeAnalyzer {
             foreach (ModuleDefinition module in modules) {
                 typeMapStep.ProcessModule(module);
 
-                if (whiteListCache != null && whiteListCache.Count > 0) {
-                    foreach (var type in module.Types) {
-                        ProcessWhiteList(type);
-                    }
+                foreach (var type in module.Types) {
+                    ProcessWhiteList(type);
                 }
             }
 
@@ -381,12 +379,13 @@ namespace JSIL.Compiler.Extensibility.DeadCodeAnalyzer {
         }
 
         private bool IsMemberWhiteListed(MemberReference member) {
-            if (whiteListCache == null)
-                return false;
-
-            foreach (var regex in whiteListCache) {
-                if (regex.IsMatch(member.FullName))
-                    return true;
+            if (whiteListCache != null)
+            {
+                foreach (var regex in whiteListCache)
+                {
+                    if (regex.IsMatch(member.FullName))
+                        return true;
+                }
             }
 
             IEnumerable<CustomAttribute> customAttributes = null;

--- a/Compiler/Analyzers/DeadCodeAnalyzer/DeadCodeInfoProvider.cs
+++ b/Compiler/Analyzers/DeadCodeAnalyzer/DeadCodeInfoProvider.cs
@@ -27,7 +27,7 @@ namespace JSIL.Compiler.Extensibility.DeadCodeAnalyzer {
             fields = new HashSet<FieldDefinition>();
             assemblies = new HashSet<AssemblyDefinition>();
 
-            if (configuration.WhiteList != null &
+            if (configuration.WhiteList != null &&
                 configuration.WhiteList.Count > 0) {
                 whiteListCache = new List<Regex>(configuration.WhiteList.Count);
                 foreach (var pattern in configuration.WhiteList) {
@@ -370,7 +370,7 @@ namespace JSIL.Compiler.Extensibility.DeadCodeAnalyzer {
             foreach (ModuleDefinition module in modules) {
                 typeMapStep.ProcessModule(module);
 
-                if (whiteListCache.Count > 0) {
+                if (whiteListCache != null && whiteListCache.Count > 0) {
                     foreach (var type in module.Types) {
                         ProcessWhiteList(type);
                     }
@@ -381,7 +381,7 @@ namespace JSIL.Compiler.Extensibility.DeadCodeAnalyzer {
         }
 
         private bool IsMemberWhiteListed(MemberReference member) {
-            if (configuration.WhiteList == null)
+            if (whiteListCache == null)
                 return false;
 
             foreach (var regex in whiteListCache) {


### PR DESCRIPTION
The DeadCodeAnalyzer will crash with a StackOverflowException and NullReferenceException when using this program:
```csharp
using System;

namespace ConsoleApplication2
{
    class Base<T>
    {
        public override string ToString()
        {
            return "base";
        }
    }

    class Class : Base<Class>
    {
        
    }

    class Program
    {
        static void Main()
        {
            var instance = new Class();
            Console.WriteLine(instance);
        }
    }
}
```

with this configuration:
```json
{
    "AnalyzerSettings": {
        "DeadCodeAnalyzer": {
            "DeadCodeElimination": true
        }
    }
}
```

StackOverflowException is thrown when a type has a generic base type referring to the derived type.

NullReferenceException is thrown when the WhiteList value is either missing, `null`, or `[]`. 
