### PR TITLE
Fix declaring reference to built-in types from enclosed type with DCE

### DIFF
--- a/JSIL/AssemblyTranslator.cs
+++ b/JSIL/AssemblyTranslator.cs
@@ -884,7 +884,7 @@ namespace JSIL {
 
             var tw = new StreamWriter(outputStream, Encoding.ASCII);
             var formatter = new JavascriptFormatter(
-                tw, this._TypeInfoProvider, Manifest, assembly, Configuration, stubbed
+                tw, this._TypeInfoProvider, Manifest, assembly, Configuration, ShouldSkipMember, stubbed
             );
 
             formatter.Comment(GetHeaderText());
@@ -1223,7 +1223,7 @@ namespace JSIL {
             return true;
         }
 
-        protected bool ShouldSkipMember(MemberReference member)
+        public bool ShouldSkipMember(MemberReference member)
         {
             if (member is MethodReference && member.Name == ".cctor")
                 return false;

--- a/JSIL/JavascriptFormatter.cs
+++ b/JSIL/JavascriptFormatter.cs
@@ -173,12 +173,15 @@ namespace JSIL.Internal {
             "System.SByte", "System.Int16", "System.Int32", "System.Int64",
             "System.Single", "System.Double", "System.String", "System.Object",
             "System.Boolean", "System.Char", "System.IntPtr", "System.UIntPtr"
-        }; 
+        };
+
+        protected readonly Func<MemberReference, bool> ShouldSkipMember;
 
         public JavascriptFormatter (
             TextWriter output, ITypeInfoSource typeInfo, 
             AssemblyManifest manifest, AssemblyDefinition assembly,
-            Configuration configuration, bool stubbed
+            Configuration configuration, Func<MemberReference, bool> shouldSkipMember,
+            bool stubbed
         ) {
             Output = output;
             TypeInfo = typeInfo;
@@ -186,6 +189,7 @@ namespace JSIL.Internal {
             Assembly = assembly;
             Configuration = configuration;
             Stubbed = stubbed;
+            ShouldSkipMember = shouldSkipMember;
 
             PrivateToken = Manifest.GetPrivateToken(assembly);
             Manifest.AssignIdentifiers();
@@ -685,7 +689,8 @@ namespace JSIL.Internal {
         public void TypeReference (TypeReference type, TypeReferenceContext context) {
             if (
                 (context != null) &&
-                (context.EnclosingType != null)
+                (context.EnclosingType != null) &&
+                !ShouldSkipMember(context.EnclosingType)
             ) {
                 if (TypeUtil.TypesAreEqual(type, context.EnclosingType, true)) {
                     // Types can reference themselves, so this prevents recursive initialization.


### PR DESCRIPTION
Fix #727.
JavascriptFormatter tried to use `$.TypeName` syntax for standard types in enclosed type context. If parent type was stripped to DCE, context is not enclosed anymore - so `$` is not defined.
@kg, probably it will be better always  pass $ as argument to `CreateEnum`/`CreateDelegate` and remove check for enclosed type? I had not tested it much, so don't know yet if there will be other problems.