### PR TITLE
Failing test case OutComplexUnionParameter

### DIFF
--- a/Tests/EmscriptenTestCases/OutComplexUnionParameter.cs
+++ b/Tests/EmscriptenTestCases/OutComplexUnionParameter.cs
@@ -1,0 +1,35 @@
+using System;
+
+using System.Runtime.InteropServices;
+
+public static class Program {
+    [StructLayout(LayoutKind.Sequential)]
+    public struct TestStruct {
+        public int I;
+        public float F;
+    }
+
+    [StructLayout(LayoutKind.Explicit)]
+    public struct TestComplexUnion {
+        [FieldOffset(0)]
+        public int I;
+        [FieldOffset(0)]
+        public TestStruct S;
+    }
+
+    [DllImport("common.dll", CallingConvention=CallingConvention.Cdecl)]
+    public static extern void WriteComplexUnionInt(int i, out TestComplexUnion result);
+
+    [DllImport("common.dll", CallingConvention = CallingConvention.Cdecl)]
+    public static extern void WriteComplexUnionStruct(int i, float f, out TestComplexUnion result);
+
+    public static void Main () {
+        TestComplexUnion result;
+        WriteComplexUnionInt(6, out result);
+
+        TestComplexUnion result2;
+        WriteComplexUnionStruct(9, 3.7f, out result2);
+
+        Console.WriteLine("i={0} i2={1} f2={2:F4}", result.I, result2.S.I, result2.S.F);
+    }
+}

--- a/Tests/EmscriptenTestCases/common/common.cpp
+++ b/Tests/EmscriptenTestCases/common/common.cpp
@@ -54,6 +54,20 @@ export(void)WriteUnionFloat(const float f, TestUnion * result) {
 	result->F = f;
 }
 
+union TestComplexUnion {
+	int I;
+	TestStruct S;
+};
+
+export(void)WriteComplexUnionInt(const int i, TestComplexUnion *result) {
+	result->I = i;
+}
+
+export(void)WriteComplexUnionStruct(const int i, const float f, TestComplexUnion *result) {
+	result->S.I = i;
+	result->S.F = f;
+}
+
 export(TestStruct) ReturnStruct (const int i, const float f) {
     TestStruct result;
     result.I = i;

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -150,6 +150,7 @@
     <None Include="EmscriptenTestCases\EnumRoundTrip.cs" />
     <None Include="AnalysisTestCases\FNABaseOffset.cs" />
     <None Include="EmscriptenTestCases\OutUnionParameter.cs" />
+    <None Include="EmscriptenTestCases\OutComplexUnionParameter.cs" />
     <Compile Include="EmscriptenTestCases\ProxiedExternFunction.cs" />
     <None Include="EmscriptenTestCases\IntPtrZeroEquality.cs" />
     <None Include="EmscriptenTestCases\StringArrayParameter.cs" />


### PR DESCRIPTION
// C# output begins //
i=6 i2=9 f2=3.7000
// JavaScript output begins //
js> // Test output begins here //
// EXCEPTION:
TypeError: cachedInstance is undefined
// STACK:
Program_TestComplexUnion_Proxy_get_S@C:\Users\Jaiden\sq\JSIL\Libraries\JSIL.Core.js line 3285 > Function:8:3
Program_Main@C:\Users\Jaiden\sq\JSIL\Tests\EmscriptenTestCases\OutComplexUnionParameter.cs.out:32:64
runTestCase@C:\Users\Jaiden\sq\JSIL\Libraries\JSIL.Shell.js:175:5
runMain@typein:5:179
shellStartup@C:\Users\Jaiden\sq\JSIL\Libraries\JSIL.Shell.js:129:5
@typein:5:319