### PR TITLE
Failing test case for representation of int[0]

### DIFF
--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -405,6 +405,7 @@
     <None Include="UnsafeTestCases\StackAlloc.cs" />
     <None Include="UnsafeTestCases\PointerOrdering.cs" />
     <None Include="UnsafeTestCases\PointerRefCast.cs" />
+    <None Include="UnsafeTestCases\ZeroLengthIntArray.cs" />
     <None Include="FailingTestCases\PassPackedArrayAsNormalArrayArgument.cs" />
     <None Include="FailingTestCases\PassNormalArrayAsPackedArrayArgument.cs" />
     <None Include="FailingTestCases\ReturnNormalArrayAsPackedArray.cs" />

--- a/Tests/UnsafeTestCases/ZeroLengthIntArray.cs
+++ b/Tests/UnsafeTestCases/ZeroLengthIntArray.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Text;
+
+using System.Runtime.InteropServices;
+
+public static class Program {
+    public static unsafe void Main () {
+        int[] arr = new int[0];
+        fixed (int* pArr = arr) {
+            Console.WriteLine("{0}", (int)pArr);
+        }
+    }
+}


### PR DESCRIPTION
A pointer to an array of zero width should be a null
pointer. Important for an odd edge case in emscripten
openal