### PR TITLE
Object virtual methods

### DIFF
--- a/JSIL/ILBlockTranslator.cs
+++ b/JSIL/ILBlockTranslator.cs
@@ -564,7 +564,7 @@ namespace JSIL {
         protected JSExpression HandleJSReplacement (
             MethodReference method, Internal.MethodInfo methodInfo, 
             JSExpression thisExpression, JSExpression[] arguments,
-            TypeReference resultType
+            TypeReference resultType, bool explicitThis
         ) {
             var metadata = methodInfo.Metadata;
             if (metadata != null) {
@@ -578,10 +578,17 @@ namespace JSIL {
                         argsDict["this"] = new JSNullLiteral(TypeSystem.Object);
                         argsDict["typeof(this)"] = Translate_TypeOf(methodInfo.DeclaringType.Definition);
                         argsDict["etypeof(this)"] = Translate_TypeOf(methodInfo.DeclaringType.Definition.GetElementType());
-                    } else if (thisExpression != null) {
+                        argsDict["declaringType(method)"] = Translate_TypeOf(methodInfo.DeclaringType.Definition);
+                        argsDict["explicitThis(method)"] = new JSBooleanLiteral(false);
+                    }
+                    else if (thisExpression != null)
+                    {
                         argsDict["this"] = thisExpression;
                         argsDict["typeof(this)"] = Translate_TypeOf(thisExpression.GetActualType(TypeSystem));
                         argsDict["etypeof(this)"] = Translate_TypeOf(thisExpression.GetActualType(TypeSystem).GetElementType());
+                        argsDict["this"] = thisExpression;
+                        argsDict["declaringType(method)"] = Translate_TypeOf(methodInfo.DeclaringType.Definition);
+                        argsDict["explicitThis(method)"] = new JSBooleanLiteral(explicitThis);
                     } 
 
                     var genericMethod = method as GenericInstanceMethod;
@@ -620,7 +627,7 @@ namespace JSIL {
             var instanceType = newExpression.GetActualType(TypeSystem);
             var jsr = HandleJSReplacement(
                 constructor, constructorInfo, new JSNullLiteral(instanceType), newExpression.Arguments.ToArray(),
-                instanceType
+                instanceType, false
             );
             if (jsr != null)
                 return jsr;
@@ -652,7 +659,7 @@ namespace JSIL {
                 if (metadata != null) {
                     var jsr = HandleJSReplacement(
                         method.Reference, methodInfo, thisExpression, arguments,
-                        method.Reference.ReturnType
+                        method.Reference.ReturnType, explicitThis
                     );
                     if (jsr != null)
                         return jsr;

--- a/JSIL/JavascriptAstEmitter.cs
+++ b/JSIL/JavascriptAstEmitter.cs
@@ -890,7 +890,7 @@ namespace JSIL {
             bool parens =
                 (ParentNode is JSBinaryOperatorExpression) || (ParentNode is JSUnaryOperatorExpression);
 
-            var regex = new Regex(@"(\$\$|\$(?'name'((etypeof|typeof|assemblyof)\([a-zA-Z0-9_]([a-zA-Z0-9_]*)\))|([a-zA-Z0-9_]([a-zA-Z0-9_]*)))|(?'text'[^\$]*)|)", RegexOptions.ExplicitCapture);
+            var regex = new Regex(@"(\$\$|\$(?'name'((etypeof|typeof|assemblyof|explicitThis|declaringType)\([a-zA-Z0-9_]([a-zA-Z0-9_]*)\))|([a-zA-Z0-9_]([a-zA-Z0-9_]*)))|(?'text'[^\$]*)|)", RegexOptions.ExplicitCapture);
 
             if (parens)
                 Output.LPar();

--- a/Libraries/JSIL.Bootstrap.js
+++ b/Libraries/JSIL.Bootstrap.js
@@ -2375,7 +2375,7 @@ $jsilcore.hashContainerBase = function ($) {
   });
 
   $.RawMethod(false, "$searchBucket", function HashContainer_SearchBucket (key) {
-    var hashCode = JSIL.ObjectHashCode(key);
+    var hashCode = JSIL.ObjectHashCode(key, true);
     var bucket = this._dict[hashCode];
     if (!bucket)
       return null;
@@ -2391,7 +2391,7 @@ $jsilcore.hashContainerBase = function ($) {
   });
 
   $.RawMethod(false, "$removeByKey", function HashContainer_Remove (key) {
-    var hashCode = JSIL.ObjectHashCode(key);
+    var hashCode = JSIL.ObjectHashCode(key, true);
     var bucket = this._dict[hashCode];
     if (!bucket)
       return false;
@@ -2410,7 +2410,7 @@ $jsilcore.hashContainerBase = function ($) {
   });
 
   $.RawMethod(false, "$addToBucket", function HashContainer_Add (key, value) {
-    var hashCode = JSIL.ObjectHashCode(key);
+    var hashCode = JSIL.ObjectHashCode(key, true);
     var bucket = this._dict[hashCode];
     if (!bucket)
       this._dict[hashCode] = bucket = [];

--- a/Libraries/JSIL.Core.js
+++ b/Libraries/JSIL.Core.js
@@ -9480,13 +9480,14 @@ if (typeof (WeakMap) !== "undefined") {
   };
 }
 
-JSIL.ObjectHashCode = function (obj) {
+JSIL.ObjectHashCode = function (obj, virtualCall, thisType) {
   var type = typeof obj;
 
-  if (type === "object") {
-    if (obj.GetHashCode)
-      return (obj.GetHashCode() | 0);
-
+  if (type === "object" || type == "string") {
+    if (obj.GetHashCode && virtualCall)
+      return (obj.GetHashCode() | 0);   
+    if (!virtualCall && thisType.__PublicInterface__.prototype.GetHashCode)
+      return (thisType.__PublicInterface__.prototype.GetHashCode.call(obj) | 0);   
     return JSIL.HashCodeInternal(obj);
   } else {
     // FIXME: Not an integer. Gross.

--- a/Libraries/JSIL.Core.js
+++ b/Libraries/JSIL.Core.js
@@ -9421,6 +9421,36 @@ JSIL.GetEqualsSignature = function () {
   return JSIL.$equalsSignature;
 }
 
+JSIL.ObjectEqualsInstance = function (lhs, rhs, virtualCall, thisType) {
+  switch (typeof (lhs)) {
+    case "string":
+    case "number":
+      return lhs == rhs;
+      break;
+
+    case "object":
+      if (virtualCall) {
+        var key = JSIL.GetEqualsSignature().GetNamedKey("Object_Equals", true);
+        var fn = lhs[key];
+
+        if (fn)
+          return fn.call(lhs, rhs);
+      }
+      else {
+          if (thisType.__PublicInterface__.prototype.Object_Equals) {
+              return thisType.__PublicInterface__.prototype.Object_Equals.call(lhs, rhs);
+          }
+      }         
+      
+      break;
+  }
+
+  if (lhs === rhs)
+    return true;
+
+  return false;
+};
+
 JSIL.ObjectEquals = function (lhs, rhs) {
   if ((lhs === null) || (rhs === null))
     return lhs === rhs;

--- a/Proxies/Object.cs
+++ b/Proxies/Object.cs
@@ -9,8 +9,9 @@ namespace JSIL.Proxies {
         typeof(Object),
         memberPolicy: JSProxyMemberPolicy.ReplaceNone,
         attributePolicy: JSProxyAttributePolicy.ReplaceDeclared
-    )]
-    public abstract class ObjectProxy {
+        )]
+    public abstract class ObjectProxy
+    {
         [JSIsPure]
         [JSExternal]
         new abstract public Type GetType ();
@@ -41,5 +42,33 @@ namespace JSIL.Proxies {
         public static bool ReferenceEquals (object objA, object objB) {
             throw new InvalidOperationException();
         }
+    }
+
+    [JSProxy(
+        typeof (Object),
+        memberPolicy: JSProxyMemberPolicy.ReplaceNone,
+        attributePolicy: JSProxyAttributePolicy.ReplaceDeclared,
+        inheritable: false)]
+    public abstract class ObjectGetHashCodeProxy
+    {
+        [JSIsPure]
+        [JSReplacement("JSIL.ObjectHashCode($this, !$explicitThis(method), $declaringType(method))")]
+        public new abstract int GetHashCode();
+    }
+
+    [JSProxy(
+        new[]
+        {
+            typeof (SByte), typeof (Int16), typeof (Int32),
+            typeof (Byte), typeof (UInt16), typeof (UInt32),
+            typeof (String)
+        },
+        memberPolicy: JSProxyMemberPolicy.ReplaceNone,
+        attributePolicy: JSProxyAttributePolicy.ReplaceDeclared)]
+    public abstract class JSTypesGetHashCodeProxy
+    {
+        [JSIsPure]
+        [JSReplacement("JSIL.ObjectHashCode($this, false)")]
+        public new abstract int GetHashCode();
     }
 }

--- a/Proxies/Object.cs
+++ b/Proxies/Object.cs
@@ -54,6 +54,9 @@ namespace JSIL.Proxies {
         [JSIsPure]
         [JSReplacement("JSIL.ObjectHashCode($this, !$explicitThis(method), $declaringType(method))")]
         public new abstract int GetHashCode();
+
+        [JSReplacement("JSIL.ObjectEqualsInstance($this, $obj, !$explicitThis(method), $declaringType(method))")]
+        new public abstract bool Equals(object obj);
     }
 
     [JSProxy(
@@ -70,5 +73,8 @@ namespace JSIL.Proxies {
         [JSIsPure]
         [JSReplacement("JSIL.ObjectHashCode($this, false)")]
         public new abstract int GetHashCode();
+
+        [JSReplacement("JSIL.ObjectEquals($this, $obj)")]
+        new public abstract bool Equals(object obj);
     }
 }

--- a/Tests/SimpleTestCases/ObjectVirtualMethods.cs
+++ b/Tests/SimpleTestCases/ObjectVirtualMethods.cs
@@ -1,0 +1,48 @@
+using System;
+
+class Program
+{
+    public static void Main()
+    {
+        // Check raw type GetHashCode
+        int i1 = 0;
+        object i2 = 0;
+        System.Console.WriteLine(i1.GetHashCode() == i2.GetHashCode()  ? "true" : "false");
+
+        // Check type with several base.GetHashCode
+        var c1 = new DerivedClass();
+        object c2 = new DerivedClass();
+
+        System.Console.WriteLine(c1.GetHashCode() == c2.GetHashCode() ? "true" : "false");
+        System.Console.WriteLine(c1.GetHashCode() == c1.GetHashCode() ? "true" : "false");
+        System.Console.WriteLine(c2.GetHashCode() == c2.GetHashCode() ? "true" : "false");
+    }
+}
+
+public class BaseClass
+{
+    public override int GetHashCode()
+    {
+        Console.WriteLine("BaseClass.GetHashCode");
+        return base.GetHashCode();
+    }
+}
+
+public class DerivedClass : BaseClass
+{
+    public void GetHashCode(string a)
+    {
+        Console.WriteLine("DerivedClass.GetHashCode(string)");
+    }
+
+    public override int GetHashCode()
+    {
+        Console.WriteLine("DerivedClass.GetHashCode");
+        return base.GetHashCode();
+    }
+
+    public void GetHashCode(int a)
+    {
+        Console.WriteLine("DerivedClass.GetHashCode(int)");
+    }
+}

--- a/Tests/SimpleTestCases/ObjectVirtualMethods.cs
+++ b/Tests/SimpleTestCases/ObjectVirtualMethods.cs
@@ -16,6 +16,17 @@ class Program
         System.Console.WriteLine(c1.GetHashCode() == c2.GetHashCode() ? "true" : "false");
         System.Console.WriteLine(c1.GetHashCode() == c1.GetHashCode() ? "true" : "false");
         System.Console.WriteLine(c2.GetHashCode() == c2.GetHashCode() ? "true" : "false");
+
+        // Equals
+        System.Console.WriteLine(i1.Equals(i2) ? "true" : "false");
+        System.Console.WriteLine(i2.Equals(i1) ? "true" : "false");
+        System.Console.WriteLine(i1.Equals(i1) ? "true" : "false");
+        System.Console.WriteLine(i2.Equals(i2) ? "true" : "false");
+
+        System.Console.WriteLine(c1.Equals(c2) ? "true" : "false");
+        System.Console.WriteLine(c2.Equals(c1) ? "true" : "false");
+        System.Console.WriteLine(c1.Equals(c1) ? "true" : "false");
+        System.Console.WriteLine(c2.Equals(c2) ? "true" : "false");
     }
 }
 
@@ -25,6 +36,18 @@ public class BaseClass
     {
         Console.WriteLine("BaseClass.GetHashCode");
         return base.GetHashCode();
+    }
+
+    public override bool Equals(object other)
+    {
+        Console.WriteLine("BaseClass.Equals");
+        return base.Equals(other);
+    }
+
+    public bool Equals(BaseClass other)
+    {
+        Console.WriteLine("BaseClass.Equals");
+        return base.Equals(other);
     }
 }
 
@@ -44,5 +67,11 @@ public class DerivedClass : BaseClass
     public void GetHashCode(int a)
     {
         Console.WriteLine("DerivedClass.GetHashCode(int)");
+    }
+
+    public override bool Equals(object other)
+    {
+        Console.WriteLine("DerivedClass.Equals");
+        return base.Equals(other);
     }
 }

--- a/Tests/SimpleTests.csproj
+++ b/Tests/SimpleTests.csproj
@@ -111,6 +111,7 @@
     <None Include="SimpleTestCases\Queue.cs" />
     <None Include="SimpleTestCases\UriBasic.cs" />
     <None Include="SimpleTestCases\NumericRoundTripCasts.cs" />
+    <None Include="SimpleTestCases\ObjectVirtualMethods.cs" />
     <Compile Include="SimpleTests.cs" />
     <None Include="SimpleTestCases\BaseAutoProperties.cs" />
     <None Include="SimpleTestCases\OverloadedVirtualMethods.cs" />

--- a/Tests/TestCases/DictionaryEnumerator.cs
+++ b/Tests/TestCases/DictionaryEnumerator.cs
@@ -3,11 +3,12 @@ using System.Collections.Generic;
 
 public static class Program {
     public static void Main (string[] args) {
+        // This test is sensitive to string hash algorithm. Order of keys may be diffirent.
         var d = new Dictionary<string, int> {
             {"a", 1},
             {"b", 2},
-            {"z", 3},
-            {"c", 4}
+            {"c", 4},
+            {"z", 3}
         };
 
         using (var e = d.GetEnumerator())

--- a/Tests/TestCases/DictionaryInterfaces.cs
+++ b/Tests/TestCases/DictionaryInterfaces.cs
@@ -103,11 +103,12 @@ public static class Program {
 
     public static Dictionary<string, int> CreateAndFill()
     {
+        // This test is sensitive to string hash algorithm. Order of keys may be diffirent.
         return new Dictionary<string, int> {
             {"a", 1},
             {"b", 2},
-            {"z", 3},
-            {"c", 4}
+            {"c", 4},
+            {"z", 3}
         };
     }
 }


### PR DESCRIPTION
Looks like I've found good enough solution for calling virtual object methods (Equals, GetHashCode) on raw JS types (string/int/double and so on).
For it I've added additional pseudo-calls to `JSReplacement` meta attribute:
- `$explicitThis(method)` - so we can pass information if we should do virtual call
- `$declaringType(method)` - so we can know method declaration type for non-virtual call.

With help of this new parameters, I changed instance virtual object methods with calling JSIL special helper functions, that know how to process raw-js object scenarios.

Test added.

After applying it we can remove hack with adding GetHashCode and Object_Equals method to string prototype - but for simplifying this PR I've not done it here.