### PR TITLE
Dce improvements (continue)

### DIFF
--- a/JSIL/AssemblyTranslator.cs
+++ b/JSIL/AssemblyTranslator.cs
@@ -460,12 +460,12 @@ namespace JSIL {
             if (AssembliesLoaded != null)
                 AssembliesLoaded(assemblies);
 
+            if (scanForProxies)
+                _TypeInfoProvider.AddProxyAssemblies(OnProxiesFoundHandler, assemblies);
+            
             if (AnalyzeStarted != null) {
                 AnalyzeStarted();
             }
-
-            if (scanForProxies)
-                _TypeInfoProvider.AddProxyAssemblies(OnProxiesFoundHandler, assemblies);
 
             var pr = new ProgressReporter();
             if (Decompiling != null)

--- a/Tests.DCE/DCETests/DCEMetaAttributes.cs
+++ b/Tests.DCE/DCETests/DCEMetaAttributes.cs
@@ -1,0 +1,61 @@
+﻿using JSIL.Meta;
+
+public static class Program
+{
+    [JSDeadCodeEleminationEntryPoint]
+    public static int UnusedFieldWithAttribute;
+
+    public static void Main()
+    {
+    }
+
+    [JSDeadCodeEleminationEntryPoint]
+    public static void UnusedMethodWithAttribute()
+    {
+    }
+}
+
+[JSDeadCodeEleminationEntryPoint]
+public class UnusedClassWithAttribute
+{
+    public void MethodInUnusedClassWithAttribute()
+    {
+    }
+}
+
+[JSDeadCodeEleminationClassEntryPoint]
+public class UnusedClassWithClassEntryPointAttribute
+{
+    public void MethodInUnusedClassWithClassEntryPointAttribute()
+    {
+    }
+}
+
+[JSDeadCodeEleminationHierarchyEntryPoint]
+public class UnusedClassWithHierarchyEntryPointAttribute
+{
+    public void MethodInUnusedClassWithHierarchyEntryPointAttribute()
+    {
+    }
+}
+
+public class DerivedUnusedClassWithAttribute : UnusedClassWithAttribute
+{
+    public void MethodInDerivedUnusedClassWithAttribute()
+    {
+    }
+}
+
+public class DerivedUnusedClassWithClassEntryPointAttribute : UnusedClassWithClassEntryPointAttribute
+{
+    public void MethodInDerivedUnusedClassWithClassEntryPointAttribute()
+    {
+    }
+}
+
+public class DerivedUnusedClassWithHierarchyEntryPointAttribute : UnusedClassWithHierarchyEntryPointAttribute
+{
+    public void MethodInDerivedUnusedClassWithHierarchyEntryPointAttribute()
+    {
+    }
+}

--- a/Tests.DCE/DCETests/DCEMetaAttributesOnProxies.cs
+++ b/Tests.DCE/DCETests/DCEMetaAttributesOnProxies.cs
@@ -1,0 +1,88 @@
+﻿using JSIL.Meta;
+using JSIL.Proxy;
+
+public static class Program
+{
+    public static int UnusedFieldWithAttribute;
+
+    public static void Main()
+    {
+    }
+
+    public static void UnusedMethodWithAttribute()
+    {
+    }
+}
+
+public class UnusedClassWithAttribute
+{
+    public void MethodInUnusedClassWithAttribute()
+    {
+    }
+}
+
+public class UnusedClassWithClassEntryPointAttribute
+{
+    public void MethodInUnusedClassWithClassEntryPointAttribute()
+    {
+    }
+}
+
+public class UnusedClassWithHierarchyEntryPointAttribute
+{
+    public void MethodInUnusedClassWithHierarchyEntryPointAttribute()
+    {
+    }
+}
+
+public class DerivedUnusedClassWithAttribute : UnusedClassWithAttribute
+{
+    public void MethodInDerivedUnusedClassWithAttribute()
+    {
+    }
+}
+
+public class DerivedUnusedClassWithClassEntryPointAttribute : UnusedClassWithClassEntryPointAttribute
+{
+    public void MethodInDerivedUnusedClassWithClassEntryPointAttribute()
+    {
+    }
+}
+
+public class DerivedUnusedClassWithHierarchyEntryPointAttribute : UnusedClassWithHierarchyEntryPointAttribute
+{
+    public void MethodInDerivedUnusedClassWithHierarchyEntryPointAttribute()
+    {
+    }
+}
+
+[JSProxy(typeof(Program), JSProxyMemberPolicy.ReplaceNone, JSProxyAttributePolicy.ReplaceDeclared, JSProxyInterfacePolicy.ReplaceDeclared, false)]
+public static class ProxyForProgram
+{
+    [JSDeadCodeEleminationEntryPoint]
+    public static int UnusedFieldWithAttribute;
+
+
+    [JSDeadCodeEleminationEntryPoint]
+    public static void UnusedMethodWithAttribute()
+    {
+    }
+}
+
+[JSProxy(typeof(UnusedClassWithAttribute), JSProxyMemberPolicy.ReplaceDeclared, JSProxyAttributePolicy.ReplaceDeclared, JSProxyInterfacePolicy.ReplaceDeclared, false)]
+[JSDeadCodeEleminationEntryPoint]
+public class ProxyForUnusedClassWithAttribute
+{
+}
+
+[JSProxy(typeof(UnusedClassWithClassEntryPointAttribute), JSProxyMemberPolicy.ReplaceDeclared, JSProxyAttributePolicy.ReplaceDeclared, JSProxyInterfacePolicy.ReplaceDeclared, false)]
+[JSDeadCodeEleminationClassEntryPoint]
+public class ProxyForUnusedClassWithClassEntryPointAttribute
+{
+}
+
+[JSProxy(typeof(UnusedClassWithHierarchyEntryPointAttribute), JSProxyMemberPolicy.ReplaceDeclared, JSProxyAttributePolicy.ReplaceDeclared, JSProxyInterfacePolicy.ReplaceDeclared, false)]
+[JSDeadCodeEleminationHierarchyEntryPoint]
+public class ProxyForUnusedClassWithHierarchyEntryPointAttribute
+{
+}

--- a/Tests.DCE/DCETests/StripOuterTypes.cs
+++ b/Tests.DCE/DCETests/StripOuterTypes.cs
@@ -1,0 +1,24 @@
+﻿using System;
+
+public static class Program
+{
+    public static void Main(string[] args)
+    {
+        new OuterType.InnerType().Run();
+    }
+}
+
+public class OuterType
+{
+    public class InnerType
+    {
+        public void Run()
+        {
+            Console.WriteLine("Run");
+        }
+    }
+}
+
+public class StrippedType
+{
+}

--- a/Tests.DCE/Tests.DCE.csproj
+++ b/Tests.DCE/Tests.DCE.csproj
@@ -79,6 +79,9 @@
     <None Include="DCETests\PreserveTypesReferencedFromGenericField.cs" />
     <None Include="DCETests\EmptyProgram.cs" />
     <None Include="DCETests\Attributes.cs" />
+    <None Include="DCETests\DCEMetaAttributes.cs" />
+    <None Include="DCETests\DCEMetaAttributesOnProxies.cs" />
+    <None Include="DCETests\StripOuterTypes.cs" />
     <Compile Include="DeadCodeEliminationTest.cs" />
     <None Include="app.config" />
     <Compile Include="Properties\AssemblyInfo.cs" />


### PR DESCRIPTION
Fixed processing of method arguments, generic parameters, return value and class generic parameters custom attributes (earlier was processed only if method/class has custom attributes).

Added initial support for MarshalInfo (#731) - for now added only CustomMarshalInfo (other may be easy added if needed - see ProcessMarshalInfo method).

We still need better test coverage for it all - but I'm not ready do it right now. Next step - improve proxy members processing.