### PR TITLE
.Net Framework 4.6 compatibility fix

### DIFF
--- a/Proxies/Net46.cs
+++ b/Proxies/Net46.cs
@@ -1,0 +1,11 @@
+﻿namespace JSIL.Proxies
+{
+    using JSIL.Meta;
+    using JSIL.Proxy;
+
+    [JSProxy("System.Resources.FastResourceComparer")]
+    [JSStubOnly]
+    public class System_Resources_FastResourceComparer
+    {
+    }
+}

--- a/Proxies/Proxies.4.0.csproj
+++ b/Proxies/Proxies.4.0.csproj
@@ -38,6 +38,7 @@
     <Compile Include="Console.cs" />
     <Compile Include="Collections.cs" />
     <Compile Include="Char.cs" />
+    <Compile Include="Net46.cs" />
     <Compile Include="Unsafe.cs" />
     <Compile Include="DateTime.cs" />
     <Compile Include="IO.cs" />


### PR DESCRIPTION
I've temporary excluded System.Resources.FastResourceComparer from translation.
Really we have an bug, that I'll report later. In:
```
    internal static unsafe int CompareOrdinal(byte* a, int byteLen, string b)
    {
      int num1 = 0;
      int num2 = 0;
      int num3 = byteLen >> 1;
      if (num3 > b.Length)
        num3 = b.Length;
      while (num2 < num3 && num1 == 0)
        num1 = (int) (ushort) ((int) *a++ | (int) *a++ << 8) - (int) b[num2++];
      if (num1 != 0)
        return num1;
      return byteLen - b.Length * 2;
    }
```
translation of `*a++` produce `a++.get()` which is syntax error in JS strict mode.