### PR TITLE
JS Numeric types are wrapped if passed as object.

### DIFF
--- a/JSIL/AST/JSLiteralTypes.cs
+++ b/JSIL/AST/JSLiteralTypes.cs
@@ -364,4 +364,26 @@ namespace JSIL.Ast {
             return PointerType;
         }
     }
+
+    public class JSWrappedLiteral : JSExpression
+    {
+        public JSWrappedLiteral(JSLiteral literal, JSType originalType) : base(literal, originalType)
+        {
+        }
+
+        public JSLiteral Literal
+        {
+            get { return (JSLiteral)Values[0]; }
+        }
+
+        public JSType OriginalType
+        {
+            get { return (JSType)Values[1]; }
+        }
+
+        public override TypeReference GetActualType(TypeSystem typeSystem)
+        {
+            return Literal.GetActualType(typeSystem);
+        }
+    }
 }

--- a/JSIL/FunctionTransformPipeline.cs
+++ b/JSIL/FunctionTransformPipeline.cs
@@ -259,6 +259,8 @@ namespace JSIL.Internal {
 
             // HACK: Something about nullables is broken so we have to do this twice. WTF?
             Enqueue(ReplaceMethodCalls);
+
+            Enqueue(WrapLiterals);
         }
 
 
@@ -505,6 +507,13 @@ namespace JSIL.Internal {
                 ));
             else
                 return true;
+        }
+
+        private bool WrapLiterals()
+        {
+            new WrapLiterals(TypeSystem).Visit(Function);
+
+            return true;
         }
     }
 

--- a/JSIL/JSIL.csproj
+++ b/JSIL/JSIL.csproj
@@ -92,6 +92,7 @@
     <Compile Include="Transforms\CacheTypeExpressions.cs" />
     <Compile Include="Transforms\CacheSignatures.cs" />
     <Compile Include="Transforms\CacheBaseMethods.cs" />
+    <Compile Include="Transforms\WrapLiterals.cs" />
     <Compile Include="Transforms\SynthesizePropertySetterReturnValues.cs" />
     <Compile Include="Transforms\IntroducePackedArrays.cs" />
     <Compile Include="Transforms\StaticAnalysis\AllocationHoisting.cs" />

--- a/JSIL/JavascriptAstEmitter.cs
+++ b/JSIL/JavascriptAstEmitter.cs
@@ -958,6 +958,16 @@ namespace JSIL {
             }
         }
 
+        public void VisitNode(JSWrappedLiteral wrappedLiteral)
+        {
+            Output.WriteRaw("JSIL.Wrap");
+            Output.LPar();
+            Visit(wrappedLiteral.OriginalType);
+            Output.Comma();
+            Visit(wrappedLiteral.Literal);
+            Output.RPar();
+        }
+
         public void VisitNode (JSBooleanLiteral b) {
             Output.Value(b.Value);
         }

--- a/Libraries/JSIL.Bootstrap.Text.js
+++ b/Libraries/JSIL.Bootstrap.Text.js
@@ -550,7 +550,7 @@ JSIL.ImplementExternals(
     $.Method({Static:true , Public:true }, "Format", 
       new JSIL.MethodSignature($jsilcore.TypeRef("System.String"), [$jsilcore.TypeRef("System.Array") /* AnyType[] */ ], []),
       function (format) {
-        format = String(format);
+        format = String(JSIL.UnWrap(format));
 
         if (arguments.length === 1)
           return format;
@@ -756,7 +756,7 @@ JSIL.ConcatString = function (/* ...values */) {
     result = String(arguments[0]);
 
   for (var i = 1, l = arguments.length; i < l; i++) {
-    var arg = arguments[i];
+    var arg = JSIL.UnWrap(arguments[i]);
     if (arg === null)
       ;
     else if (typeof (arg) === "string")

--- a/Libraries/JSIL.Bootstrap.js
+++ b/Libraries/JSIL.Bootstrap.js
@@ -86,7 +86,7 @@ $jsilcore.$MakeParseExternals = function ($, type, parse, tryParse) {
 JSIL.ImplementExternals(
   "System.Boolean", function ($) {
     $.RawMethod(true, "CheckType", function (value) {
-      return (value === false) || (value === true);
+      return ((value === false) || (value === true)) || (value !== null && value.__ThisTypeId__ == $jsilcore.System.Boolean.__TypeId__);
     });
 
     $jsilcore.$MakeParseExternals($, $.Boolean, $jsilcore.$ParseBoolean, $jsilcore.$TryParseBoolean);
@@ -97,7 +97,7 @@ JSIL.MakeNumericType(Boolean, "System.Boolean", true);
 JSIL.ImplementExternals(
   "System.Char", function ($) {
     $.RawMethod(true, "CheckType", function (value) {
-      return (typeof (value) === "string") && (value.length == 1);
+      return ((typeof (value) === "string") && (value.length == 1)) || (value !== null && value.__ThisTypeId__ == $jsilcore.System.Char.__TypeId__);
     });
 
 		$.Constant({Public: true, Static: true}, "MaxValue", "\uffff");
@@ -109,7 +109,7 @@ JSIL.MakeNumericType(String, "System.Char", true);
 JSIL.ImplementExternals(
   "System.Byte", function ($) {
     $.RawMethod(true, "CheckType", function (value) {
-      return (typeof (value) === "number") && (value >= 0) && (value <= 255);
+      return ((typeof (value) === "number") && (value >= 0) && (value <= 255)) || (value !== null && value.__ThisTypeId__ == $jsilcore.System.Byte.__TypeId__);
     });
     
 		$.Constant({Public: true, Static: true}, "MinValue", 0);
@@ -121,7 +121,7 @@ JSIL.MakeNumericType(Number, "System.Byte", true, "Uint8Array");
 JSIL.ImplementExternals(
   "System.SByte", function ($) {
     $.RawMethod(true, "CheckType", function (value) {
-      return (typeof (value) === "number") && (value >= -128) && (value <= 127);
+      return ((typeof (value) === "number") && (value >= -128) && (value <= 127)) || (value !== null && value.__ThisTypeId__ == $jsilcore.System.SByte.__TypeId__);
     });
     
 		$.Constant({Public: true, Static: true}, "MinValue", -128);
@@ -157,7 +157,7 @@ $jsilcore.$TryParseInt = function (text, style, result) {
 JSIL.ImplementExternals(
   "System.UInt16", function ($) {
     $.RawMethod(true, "CheckType", function (value) {
-      return (typeof (value) === "number") && (value >= 0);
+      return ((typeof (value) === "number") && (value >= 0))  || (value !== null && value.__ThisTypeId__ == $jsilcore.System.UInt16.__TypeId__);
     });
 
     $jsilcore.$MakeParseExternals($, $.UInt16, $jsilcore.$ParseInt, $jsilcore.$TryParseInt);
@@ -171,7 +171,7 @@ JSIL.MakeNumericType(Number, "System.UInt16", true, "Uint16Array");
 JSIL.ImplementExternals(
   "System.Int16", function ($) {
     $.RawMethod(true, "CheckType", function (value) {
-      return (typeof (value) === "number");
+      return (typeof (value) === "number")  || (value !== null && value.__ThisTypeId__ == $jsilcore.System.Int16.__TypeId__);
     });
 
     $jsilcore.$MakeParseExternals($, $.Int16, $jsilcore.$ParseInt, $jsilcore.$TryParseInt);
@@ -185,7 +185,7 @@ JSIL.MakeNumericType(Number, "System.Int16", true, "Int16Array");
 JSIL.ImplementExternals(
   "System.UInt32", function ($) {
     $.RawMethod(true, "CheckType", function (value) {
-      return (typeof (value) === "number") && (value >= 0);
+      return ((typeof (value) === "number") && (value >= 0))  || (value !== null && value.__ThisTypeId__ == $jsilcore.System.UInt32.__TypeId__);
     });
 
     $jsilcore.$MakeParseExternals($, $.UInt32, $jsilcore.$ParseInt, $jsilcore.$TryParseInt);
@@ -199,7 +199,7 @@ JSIL.MakeNumericType(Number, "System.UInt32", true, "Uint32Array");
 JSIL.ImplementExternals(
   "System.Int32", function ($) {
     $.RawMethod(true, "CheckType", function (value) {
-      return (typeof (value) === "number");
+      return (typeof (value) === "number") || (value !== null && value.__ThisTypeId__ == $jsilcore.System.Int32.__TypeId__);
     });
 
     $jsilcore.$MakeParseExternals($, $.Int32, $jsilcore.$ParseInt, $jsilcore.$TryParseInt);
@@ -250,7 +250,7 @@ $jsilcore.$TryParseFloat = function (text, style, result) {
 JSIL.ImplementExternals(
   "System.Single", function ($) {
     $.RawMethod(true, "CheckType", function (value) {
-      return (typeof (value) === "number");
+      return (typeof (value) === "number")  || (value !== null && value.__ThisTypeId__ == $jsilcore.System.Single.__TypeId__);
     });
 
     $jsilcore.$MakeParseExternals($, $.Single, $jsilcore.$ParseFloat, $jsilcore.$TryParseFloat);
@@ -268,7 +268,7 @@ JSIL.MakeNumericType(Number, "System.Single", false, "Float32Array");
 JSIL.ImplementExternals(
   "System.Double", function ($) {
     $.RawMethod(true, "CheckType", function (value) {
-      return (typeof (value) === "number");
+      return (typeof (value) === "number") || (value !== null && value.__ThisTypeId__ == $jsilcore.System.Double.__TypeId__);
     });
 
     $jsilcore.$MakeParseExternals($, $.Single, $jsilcore.$ParseFloat, $jsilcore.$TryParseFloat);

--- a/Libraries/JSIL.Core.Reflection.js
+++ b/Libraries/JSIL.Core.Reflection.js
@@ -959,8 +959,13 @@ JSIL.ImplementExternals("System.Reflection.MethodInfo", function ($) {
       if (parameters !== null) {
         parameters = parameters.slice();
         for (var i = 0; i < parametersCount; i++) {
-          if (parameters[i] === null && parameterTypes[i].IsValueType)
-            parameters[i] = JSIL.DefaultValue(parameterTypes[i]);
+          if (parameterTypes[i].IsValueType) {
+              if (parameters[i] === null ) {
+                  parameters[i] = JSIL.DefaultValue(parameterTypes[i]);
+              } else {
+                  parameters[i] = JSIL.UnWrap(parameters[i]);
+              }
+          }
         }
       }
       

--- a/Proxies/Numbers.cs
+++ b/Proxies/Numbers.cs
@@ -30,7 +30,7 @@ namespace JSIL.Proxies {
 
         [JSIsPure]
         [JSReplacement("($this === $rhs)")]
-        public bool Equals (AnyType rhs) {
+        public bool Equals (IntegerProxy rhs) {
             throw new InvalidOperationException();
         }
 
@@ -69,7 +69,7 @@ namespace JSIL.Proxies {
 
         [JSIsPure]
         [JSReplacement("($this === $rhs)")]
-        public bool Equals (AnyType rhs) {
+        public bool Equals(NumberProxy rhs) {
             throw new InvalidOperationException();
         }
 

--- a/Tests/SimpleTestCases/ResolveWrappedNumericType.cs
+++ b/Tests/SimpleTestCases/ResolveWrappedNumericType.cs
@@ -1,0 +1,22 @@
+using System;
+
+public static class Program
+{
+    public static void Main(string[] args)
+    {
+        TestType('a');
+        TestType(false);
+        TestType(3d);
+        TestType(3f);
+        TestType(3m);
+        TestType(3);
+        TestType(3u);
+        TestType(3L);
+        TestType(3uL);
+    }
+
+    public static void TestType(object input)
+    {
+        Console.WriteLine(input.GetType().Name);
+    }
+}

--- a/Tests/SimpleTests.csproj
+++ b/Tests/SimpleTests.csproj
@@ -114,6 +114,7 @@
     <None Include="SimpleTestCases\ObjectVirtualMethods.cs" />
     <None Include="SimpleTestCases\RawTypeIsObject_Issue754.cs" />
     <None Include="SimpleTestCases\HashSetSameHash_Issue752.cs" />
+    <None Include="SimpleTestCases\ResolveWrappedNumericType.cs" />
     <Compile Include="SimpleTests.cs" />
     <None Include="SimpleTestCases\BaseAutoProperties.cs" />
     <None Include="SimpleTestCases\OverloadedVirtualMethods.cs" />


### PR DESCRIPTION
I've tried to implement fix for #349 - as was discussed, boxed numeric types are also boxed from Raw JS types in JavaScript.
This PR is still **not ready for merging**, but @kg, I'd like to discuss it with you and probably will need your help.
- With this change dynamic work with numeric types was broken. Please look on DynamicBinaryOperators test for example. As dynamic variables are objects, integers are wrapped. I've not found how can I avoid this behavior, as I have no information that I'm processing translated dynamic CallSite in my WrapLiterals visitors - that information was stripped on function translation
- Second problem is VerbatimVariablesExistingArray test. Integers inside `object[]` are wrapped, so probable `Verbatim.Expression` should unwrap them. On other side, it may not be a problem at all as can be solved inside expression by end user.

Then, not all problems are solved:
- We still need resolve type based on it's information in translation-time if it is unwrapped - as you suggested in first comment to #349.
- Type of expressions like `(byte)12` incorrectly treated as `Int32` - this information is lost inside `ILBlockTranslator.Translate_Box` method. Should discuss how we can solve it.