### PR TITLE
Reflection additions

### DIFF
--- a/JSIL.Libraries/Includes/Core/Reflection/Classes/System.Reflection.PropertyInfo.js
+++ b/JSIL.Libraries/Includes/Core/Reflection/Classes/System.Reflection.PropertyInfo.js
@@ -10,7 +10,11 @@
     return this.get_DeclaringType().GetMethod(methodName, bindingFlags);
   };
 
-  var getSetMethodImpl = function (nonPublic) {
+  var getValueImpl = function(obj, index) {
+    return getGetMethodImpl.call(this, true).Invoke(obj, index);
+  };
+
+  var getSetMethodImpl = function(nonPublic) {
     var methodName = "set_" + this.get_Name();
     var bf = System.Reflection.BindingFlags;
     var instanceOrStatic = this.get_IsStatic() ? "Static" : "Instance";
@@ -19,6 +23,10 @@
       : bf.$Flags("DeclaredOnly", instanceOrStatic, "Public")
     );
     return this.get_DeclaringType().GetMethod(methodName, bindingFlags);
+  };
+
+  var setValueImpl = function(obj, value, index) {
+    return getSetMethodImpl.call(this, true).Invoke(obj, index !== null ? Array.prototype.concat(index, value) : [value]);
   };
 
   var getAccessorsImpl = function (nonPublic) {
@@ -80,6 +88,30 @@
 
       return [];
     }
+  );
+
+  $.Method({ Static: false, Public: true }, "GetValue",
+    (new JSIL.MethodSignature($.Object, [$.Object], [], [])),
+    function GetValue(obj) {
+      return getValueImpl.call(this, obj, null);
+    }
+  );
+
+  $.Method({ Static: false, Public: true }, "GetValue",
+    (new JSIL.MethodSignature($.Object, [$.Object, $jsilcore.TypeRef("System.Array", [$.Object])], [], [])),
+    getValueImpl
+  );
+
+  $.Method({ Static: false, Public: true }, "SetValue",
+    (new JSIL.MethodSignature($.Object, [$.Object, $.Object], [], [])),
+    function GetValue(obj, value) {
+      return setValueImpl.call(this, obj, value, null);
+    }
+  );
+
+  $.Method({ Static: false, Public: true }, "SetValue",
+    (new JSIL.MethodSignature($.Object, [$.Object, $.Object, $jsilcore.TypeRef("System.Array", [$.Object])], [], [])),
+    setValueImpl
   );
 
   $.Method({ Static: false, Public: true }, "get_PropertyType",

--- a/JSIL.Libraries/Includes/Core/Reflection/Classes/System.Reflection.TypeInfo.js
+++ b/JSIL.Libraries/Includes/Core/Reflection/Classes/System.Reflection.TypeInfo.js
@@ -1,0 +1,2 @@
+﻿JSIL.MakeClass("System.Type", "System.Reflection.TypeInfo", false, [], function ($) {
+});

--- a/JSIL.Libraries/Includes/Core/Reflection/Classes/System.RuntimeType.js
+++ b/JSIL.Libraries/Includes/Core/Reflection/Classes/System.RuntimeType.js
@@ -1,3 +1,3 @@
-﻿JSIL.MakeClass("System.Type", "System.RuntimeType", false, [], function ($) {
+﻿JSIL.MakeClass("System.Reflection.TypeInfo", "System.RuntimeType", false, [], function ($) {
   $jsilcore.RuntimeTypeInitialized = true;
 });

--- a/JSIL.Libraries/Includes/Core/Reflection/Classes/System.Type.js
+++ b/JSIL.Libraries/Includes/Core/Reflection/Classes/System.Type.js
@@ -464,13 +464,6 @@
       }
     );
 
-    $.Method({ Public: true, Static: false }, "GetType",
-      new JSIL.MethodSignature($.Type, []),
-      function () {
-        return $jsilcore.System.Type.__Type__;
-      }
-    );
-
     $.Method({ Public: true, Static: false }, "get_IsGenericParameter",
       new JSIL.MethodSignature($.Type, []),
       JSIL.TypeObjectPrototype.get_IsGenericParameter

--- a/JSIL.Libraries/Includes/Core/Reflection/Classes/System.Type.js
+++ b/JSIL.Libraries/Includes/Core/Reflection/Classes/System.Type.js
@@ -328,7 +328,7 @@
           $jsilcore.TypeRef("System.Array", [$jsilcore.TypeRef("System.Reflection.ParameterModifier")])
       ], []),
       function GetConstructor(bindingAttr, binder, callConvention, types, modifiers) {
-        return getConstructorImpl(this, bindingAttr, types);
+        return getConstructorImpl(this, bindingAttr | System.Reflection.BindingFlags.DeclaredOnly, types);
       }
     );
 
@@ -338,7 +338,7 @@
           $jsilcore.TypeRef("System.Array", [$jsilcore.TypeRef("System.Type")]), $jsilcore.TypeRef("System.Array", [$jsilcore.TypeRef("System.Reflection.ParameterModifier")])
       ], []),
       function GetConstructor(bindingAttr, binder, types, modifiers) {
-        return getConstructorImpl(this, bindingAttr, types);
+        return getConstructorImpl(this, bindingAttr | System.Reflection.BindingFlags.DeclaredOnly, types);
       }
     );
 
@@ -363,7 +363,7 @@
       new JSIL.MethodSignature(methodArray, [$jsilcore.TypeRef("System.Reflection.BindingFlags")]),
       function (flags) {
         return JSIL.GetMembersInternal(
-          this, flags, "ConstructorInfo"
+          this, flags | System.Reflection.BindingFlags.DeclaredOnly, "ConstructorInfo"
         );
       }
     );

--- a/JSIL.Libraries/Includes/Core/Reflection/Classes/System.Type.js
+++ b/JSIL.Libraries/Includes/Core/Reflection/Classes/System.Type.js
@@ -130,6 +130,13 @@
       JSIL.TypeObjectPrototype.get_AssemblyQualifiedName
     );
 
+    $.Method({ Public: true, Static: false }, "get_IsClass",
+      new JSIL.MethodSignature($.Boolean, []),
+      function () {
+        return this === $jsilcore.System.Object.__Type__ || this.get_BaseType() !== null;
+      }
+    );
+
     $.Method({ Public: true, Static: false }, "toString",
       new JSIL.MethodSignature($.String, []),
       function () {
@@ -596,4 +603,5 @@ JSIL.MakeClass("System.Reflection.MemberInfo", "System.Type", true, [], function
   $.Property({ Public: true, Static: false }, "IsArray");
   $.Property({ Public: true, Static: false }, "IsValueType");
   $.Property({ Public: true, Static: false }, "IsEnum");
+  $.Property({ Public: true, Static: false }, "IsClass");
 });

--- a/JSIL.Libraries/Includes/Core/Reflection/Main.js
+++ b/JSIL.Libraries/Includes/Core/Reflection/Main.js
@@ -18,6 +18,8 @@ if (!$jsilcore)
 //? include("Classes/System.Reflection.MethodInfo.js"); writeln();
 
 //? include("Classes/System.RuntimeType.js"); writeln();
+//? include("Classes/System.Reflection.TypeInfo.js"); writeln();
+
 //? include("Classes/System.Reflection.ConstructorInfo.js"); writeln();
 //? include("Classes/System.Reflection.EventInfo.js"); writeln();
 

--- a/JSIL.Libraries/Includes/Core/Reflection/Utils/$jsilcore.MemberInfoExternals.js
+++ b/JSIL.Libraries/Includes/Core/Reflection/Utils/$jsilcore.MemberInfoExternals.js
@@ -49,6 +49,13 @@ $jsilcore.MemberInfoExternals = function ($) {
     }
   );
 
+  $.Method({ Static: false, Public: true }, "IsDefined",
+    (new JSIL.MethodSignature($.Boolean, [$jsilcore.TypeRef("System.Type"), $.Boolean], [])),
+    function GetCustomAttributes(attributeType, inherit) {
+      return JSIL.GetMemberAttributes(this, inherit, attributeType).length > 0;
+    }
+  );
+
   $.Method({ Static: false, Public: true }, "GetCustomAttributesData",
     (new JSIL.MethodSignature($jsilcore.TypeRef("System.Collections.Generic.IList`1", [$jsilcore.TypeRef("System.Reflection.CustomAttributeData")]), [], [])),
     function GetCustomAttributesData() {

--- a/JSIL.Libraries/JSIL.Libraries.csproj
+++ b/JSIL.Libraries/JSIL.Libraries.csproj
@@ -128,6 +128,7 @@
     <Content Include="Includes\Core\Reflection\Classes\System.Reflection.RuntimeAssembly.js" />
     <Content Include="Includes\Core\Reflection\Classes\System.Reflection.EventInfo.js" />
     <Content Include="Includes\Core\Reflection\Classes\System.Reflection.ConstructorInfo.js" />
+    <Content Include="Includes\Core\Reflection\Classes\System.Reflection.TypeInfo.js" />
     <Content Include="Includes\Core\Reflection\Classes\System.RuntimeType.js" />
     <Content Include="Includes\Core\Reflection\Classes\System.Reflection.Assembly.js" />
     <Content Include="Includes\Core\Reflection\Classes\System.Reflection.MethodInfo.js" />

--- a/JSIL.Libraries/Sources/JSIL.Core.js
+++ b/JSIL.Libraries/Sources/JSIL.Core.js
@@ -9577,7 +9577,7 @@ JSIL.GetMemberAttributes = function (memberInfo, inherit, attributeType, result)
   var memberType = memberInfo.GetType().get_FullName();
 
   if (inherit) {
-    if (memberType !== "System.Type")
+    if (memberType !== "System.RuntimeType")
       throw new System.NotImplementedException("Inherited attributes only supported for types");
 
     if (!result)

--- a/JSIL/AssemblyTranslator.cs
+++ b/JSIL/AssemblyTranslator.cs
@@ -105,7 +105,8 @@ namespace JSIL {
         protected bool OwnsTypeInfoProvider;
 
         protected readonly static HashSet<string> TypeDeclarationsToSuppress = new HashSet<string> {
-            "System.Object", "System.ValueType", "System.Type", "System.RuntimeType",
+            "System.Object", "System.ValueType",
+            "System.Type", "System.Reflection.TypeInfo", "System.RuntimeType",
             "System.Reflection.MemberInfo", "System.Reflection.MethodBase", 
             "System.Reflection.MethodInfo", "System.Reflection.FieldInfo",
             "System.Reflection.ConstructorInfo", "System.Reflection.PropertyInfo", "System.Reflection.EventInfo",

--- a/Tests/ReflectionTestCases/GetInheritedAttributesFromMethods.cs
+++ b/Tests/ReflectionTestCases/GetInheritedAttributesFromMethods.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Reflection;
+
+public static class Program
+{
+    public static void Main(string[] args)
+    {
+        WriteInfo(typeof(Derived2).GetMethod("Method1"));
+        WriteInfo(typeof(Derived2).GetMethod("Method2"));
+        WriteInfo(typeof(Derived2).GetMethod("NonVirtualMethod"));
+        WriteInfo(typeof(Derived2).GetMethod("GenericMethod"));
+        WriteInfo(typeof(Derived2).GetMethod("GenericMethod").MakeGenericMethod(typeof(Base)));
+
+        WriteInfo(typeof(GenericDerived2<,>).GetMethod("Method1"));
+        WriteInfo(typeof(GenericDerived2<,>).GetMethod("Method2"));
+        WriteInfo(typeof(GenericDerived2<,>).GetMethod("NonVirtualMethod"));
+        WriteInfo(typeof(GenericDerived2<,>).GetMethod("GenericMethod"));
+        WriteInfo(typeof(GenericDerived2<,>).GetMethod("GenericMethod").MakeGenericMethod(typeof(Base)));
+
+        WriteInfo(typeof(GenericDerived2<Base, Base>).GetMethod("Method1"));
+        WriteInfo(typeof(GenericDerived2<Base, Base>).GetMethod("Method2"));
+        WriteInfo(typeof(GenericDerived2<Base, Base>).GetMethod("NonVirtualMethod"));
+        WriteInfo(typeof(GenericDerived2<Base, Base>).GetMethod("GenericMethod"));
+        WriteInfo(typeof(GenericDerived2<Base, Base>).GetMethod("GenericMethod").MakeGenericMethod(typeof(Base)));
+
+        WriteInfo(typeof(PartialGenericHolder<Base>).GetField("Field").FieldType.GetMethod("Method1"));
+        WriteInfo(typeof(PartialGenericHolder<Base>).GetField("Field").FieldType.GetMethod("Method2"));
+        WriteInfo(typeof(PartialGenericHolder<Base>).GetField("Field").FieldType.GetMethod("NonVirtualMethod"));
+        WriteInfo(typeof(PartialGenericHolder<Base>).GetField("Field").FieldType.GetMethod("GenericMethod"));
+        WriteInfo(typeof(PartialGenericHolder<Base>).GetField("Field").FieldType.GetMethod("GenericMethod").MakeGenericMethod(typeof(Base)));
+    }
+
+    public static void WriteInfo(MemberInfo item)
+    {
+        Console.WriteLine(item.Name);
+        Console.WriteLine(item.GetCustomAttributes(typeof(CustomAttribute), true).Length);
+        Console.WriteLine(item.GetCustomAttributes(typeof(CustomAttribute), false).Length);
+    }
+}
+
+public class Base
+{
+    public virtual void Method1() { }
+
+    [Custom]
+    public virtual void Method2() { }
+
+    [Custom]
+    public void NonVirtualMethod() { }
+
+    [Custom]
+    public virtual void GenericMethod<TA>(TA in1) { }
+}
+
+public class Derived : Base
+{
+    [Custom]
+    public override void Method1() { }
+}
+
+public class Derived2 : Derived
+{
+    public override void Method1() { }
+    public override void Method2() { }
+
+
+    public new void NonVirtualMethod() { }
+    public override void GenericMethod<TA>(TA in1) { }
+}
+
+public class GenericBase<T1, T2>
+{
+    public virtual void Method1() { }
+
+    [Custom]
+    public virtual void Method2() { }
+
+    [Custom]
+    public void NonVirtualMethod() { }
+
+    [Custom]
+    public virtual void GenericMethod<TA>(TA in1) { }
+}
+
+public class GenericDerived<T1, T2> : GenericBase<T1, T2>
+{
+    [Custom]
+    public override void Method1() { }
+}
+
+public class GenericDerived2<T1, T2> : GenericDerived<T1, T2>
+{
+    public override void Method1() { }
+    public override void Method2() { }
+
+
+    public new void NonVirtualMethod() { }
+    public override void GenericMethod<TA>(TA in1) { }
+}
+
+public class PartialGenericHolder<T2>
+{
+    public GenericDerived2<Base, T2> Field;
+}
+
+[AttributeUsage(AttributeTargets.All, Inherited = true)]
+public class CustomAttribute : Attribute
+{
+    public Type T;
+}

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -68,7 +68,7 @@
       <HintPath>..\packages\NUnitTestAdapter.2.0.0\lib\nunit.core.interfaces.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL" >
+    <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
@@ -296,6 +296,7 @@
     <None Include="SpecialTestCases\TranslateMethodInStubbedType.cs" />
     <None Include="FailingTestCases\DelegateMethod_ResolveInterface_Issue604.cs" />
     <None Include="PerformanceTestCases\GenericMethodCalls.cs" />
+    <None Include="ReflectionTestCases\GetInheritedAttributesFromMethods.cs" />
     <Compile Include="TypeInformationTests.cs" />
     <None Include="TestCases\LongArithmetic.cs" />
     <None Include="InterfaceTestCases\NestedInterfaces.cs" />


### PR DESCRIPTION
1. Added System.Reflection.TypeInfo, System.RuntimeType derived from it now.
2. typeof(T).GetType() returns typeof(System.RuntimeType)
3. JSIL.GetMemberAttributes inherit support for MethodInfo.
4. GetConstructors always use DeclaredOnly internally (test added).
5. MemberInfo.IsDefined impelemented.
6. PropertyInfo GetValue/SetValue.
7. Type.IsClass implemented.