### PR TITLE
Source map initial support

### DIFF
--- a/JSIL/AST/JSAstVisitor.cs
+++ b/JSIL/AST/JSAstVisitor.cs
@@ -19,21 +19,6 @@ namespace JSIL.Ast {
             public string ChildName;
         }
 
-        public class NodeProcessedEventArg : EventArgs
-        {
-            public JSNode Node { get; private set; }
-
-            public NodeProcessedEventArg(JSNode node)
-            {
-                if (node == null)
-                {
-                    throw new ArgumentNullException("node");
-                }
-
-                Node = node;
-            }
-        }
-
         public const int DefaultStackSize = 32;
 
         public readonly Stack<JSNode> Stack = new Stack<JSNode>(DefaultStackSize);
@@ -55,7 +40,7 @@ namespace JSIL.Ast {
 
         protected bool VisitNestedFunctions = false;
 
-        protected event EventHandler<NodeProcessedEventArg> AfterNodeProcessed;
+        protected event Action<JSNode> AfterNodeProcessed;
 
         protected JSAstVisitor () {
             Visitors = VisitorCache.Get(this);
@@ -236,7 +221,7 @@ namespace JSIL.Ast {
 
             if (node != null && AfterNodeProcessed != null)
             {
-                AfterNodeProcessed(this, new NodeProcessedEventArg(node));
+                AfterNodeProcessed(node);
             }
         }
 

--- a/JSIL/AST/JSAstVisitor.cs
+++ b/JSIL/AST/JSAstVisitor.cs
@@ -21,7 +21,7 @@ namespace JSIL.Ast {
 
         public class NodeProcessedEventArg : EventArgs
         {
-            public JSNode Node { get; }
+            public JSNode Node { get; private set; }
 
             public NodeProcessedEventArg(JSNode node)
             {

--- a/JSIL/AST/JSAstVisitor.cs
+++ b/JSIL/AST/JSAstVisitor.cs
@@ -169,7 +169,7 @@ namespace JSIL.Ast {
         /// </summary>
         /// <param name="node">The node to visit.</param>
         /// <param name="name">The name to annotate the node with, if any.</param>
-        public void Visit (JSNode node, string name = null) {
+        public virtual void Visit (JSNode node, string name = null) {
             if (node is JSFunctionExpression) {
                 // HACK: No better place to put this at present.
                 // AST visitors shouldn't recurse into nested functions because those function(s)

--- a/JSIL/AST/JSNodeTypes.cs
+++ b/JSIL/AST/JSNodeTypes.cs
@@ -15,6 +15,7 @@ using JSIL.Ast.Traversal;
 using JSIL.Internal;
 using JSIL.Transforms;
 using Mono.Cecil;
+using Mono.Cecil.Cil;
 
 namespace JSIL.Ast {
     public abstract class JSNode {
@@ -43,6 +44,8 @@ namespace JSIL.Ast {
                 return _NodeSelfAndBaseTypeIds;
             }
         }
+
+        public SequencePoint[] SymbolInfo { get; set; }
 
         public static Type[] NodeTypes {
             get {

--- a/JSIL/AST/JSNodeTypes.cs
+++ b/JSIL/AST/JSNodeTypes.cs
@@ -45,7 +45,7 @@ namespace JSIL.Ast {
             }
         }
 
-        public SequencePoint[] SymbolInfo { get; set; }
+        public IEnumerable<SequencePoint> SymbolInfo { get; set; }
 
         public static Type[] NodeTypes {
             get {

--- a/JSIL/Configuration.cs
+++ b/JSIL/Configuration.cs
@@ -115,6 +115,7 @@ namespace JSIL.Translator {
         public string FilenameEscapeRegex;
         public string AssemblyCollectionName;
         public string EmitterFactoryName;
+        public bool? BuildSourceMap;
 
         public double? FrameworkVersion;
 
@@ -156,6 +157,9 @@ namespace JSIL.Translator {
                 result.AssemblyCollectionName = AssemblyCollectionName;
             if (EmitterFactoryName != null)
                 result.EmitterFactoryName = EmitterFactoryName;
+
+            if (BuildSourceMap != null)
+                result.BuildSourceMap = BuildSourceMap;
 
             Assemblies.MergeInto(result.Assemblies);
             CodeGenerator.MergeInto(result.CodeGenerator);

--- a/JSIL/JSIL.csproj
+++ b/JSIL/JSIL.csproj
@@ -84,6 +84,7 @@
     <Compile Include="PackedStructArray.cs" />
     <Compile Include="Progress.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SourceMapBuilder.cs" />
     <Compile Include="SpecialIdentifiers.cs" />
     <Compile Include="Threading.cs" />
     <Compile Include="Transforms\CacheTypeExpressions.cs" />

--- a/JSIL/JavascriptAstEmitter.cs
+++ b/JSIL/JavascriptAstEmitter.cs
@@ -62,6 +62,11 @@ namespace JSIL {
             OverflowCheckStack.Push(false);
 
             VisitNestedFunctions = true;
+
+            if (output.SourceMapBuilder != null)
+            {
+                AfterNodeProcessed += AddSourceMapInfo;
+            }
         }
 
         TypeSystem IAstEmitter.TypeSystem {
@@ -78,16 +83,6 @@ namespace JSIL {
 
         void IAstEmitter.Emit (JSNode node) {
             this.Visit(node);
-        }
-
-        public override void Visit(JSNode node, string name = null)
-        {
-            base.Visit(node, name);
-            if (Output.SourceMapBuilder != null && node != null && node.SymbolInfo != null && node.SymbolInfo.Any())
-            {
-                Output.SourceMapBuilder.AddInfo(Output.Output.Line, Output.Output.FirstNonSpace, node.SymbolInfo);
-                //Output.Comment(string.Join("; ", node.SymbolInfo.Select(item => item.StartLine + ":" + item.StartColumn)));
-            }
         }
 
         public void CommaSeparatedList (IEnumerable<JSExpression> values, bool withNewlines = false) {
@@ -2559,6 +2554,15 @@ namespace JSIL {
             Output.WriteRaw("function () { return ");
             Visit(function.InnerExpression);
             Output.WriteRaw("; }.bind(this)");
+        }
+
+        private void AddSourceMapInfo(object source, NodeProcessedEventArg eventArgs)
+        {
+            if (eventArgs.Node.SymbolInfo != null && eventArgs.Node.SymbolInfo.Any())
+            {
+                Output.SourceMapBuilder.AddInfo(Output.OutputWithPositionInfo.Line, Output.OutputWithPositionInfo.FirstNonSpace, eventArgs.Node.SymbolInfo);
+                //Output.Comment(string.Join("; ", node.SymbolInfo.Select(item => item.StartLine + ":" + item.StartColumn)));
+            }
         }
     }
 }

--- a/JSIL/JavascriptAstEmitter.cs
+++ b/JSIL/JavascriptAstEmitter.cs
@@ -14,6 +14,8 @@ using JSIL.Translator;
 using Mono.Cecil;
 
 namespace JSIL {
+    using Mono.Cecil.Cil;
+
     public enum BlockType {
         Switch,
         While,
@@ -76,6 +78,16 @@ namespace JSIL {
 
         void IAstEmitter.Emit (JSNode node) {
             this.Visit(node);
+        }
+
+        public override void Visit(JSNode node, string name = null)
+        {
+            base.Visit(node, name);
+            if (Output.SourceMapBuilder != null && node.SymbolInfo != null && node.SymbolInfo.Any())
+            {
+                Output.SourceMapBuilder.AddInfo(Output.Output.Line, Output.Output.FirstNonSpace, node.SymbolInfo);
+                //Output.Comment(string.Join("; ", node.SymbolInfo.Select(item => item.StartLine + ":" + item.StartColumn)));
+            }
         }
 
         public void CommaSeparatedList (IEnumerable<JSExpression> values, bool withNewlines = false) {

--- a/JSIL/JavascriptAstEmitter.cs
+++ b/JSIL/JavascriptAstEmitter.cs
@@ -2556,11 +2556,11 @@ namespace JSIL {
             Output.WriteRaw("; }.bind(this)");
         }
 
-        private void AddSourceMapInfo(object source, NodeProcessedEventArg eventArgs)
+        private void AddSourceMapInfo(JSNode node)
         {
-            if (eventArgs.Node.SymbolInfo != null && eventArgs.Node.SymbolInfo.Any())
+            if (node.SymbolInfo != null && node.SymbolInfo.Any())
             {
-                Output.SourceMapBuilder.AddInfo(Output.OutputWithPositionInfo.Line, Output.OutputWithPositionInfo.FirstNonSpace, eventArgs.Node.SymbolInfo);
+                Output.SourceMapBuilder.AddInfo(Output.OutputWithPositionInfo.Line, Output.OutputWithPositionInfo.FirstNonSpace, node.SymbolInfo);
                 //Output.Comment(string.Join("; ", node.SymbolInfo.Select(item => item.StartLine + ":" + item.StartColumn)));
             }
         }

--- a/JSIL/JavascriptAstEmitter.cs
+++ b/JSIL/JavascriptAstEmitter.cs
@@ -83,7 +83,7 @@ namespace JSIL {
         public override void Visit(JSNode node, string name = null)
         {
             base.Visit(node, name);
-            if (Output.SourceMapBuilder != null && node.SymbolInfo != null && node.SymbolInfo.Any())
+            if (Output.SourceMapBuilder != null && node != null && node.SymbolInfo != null && node.SymbolInfo.Any())
             {
                 Output.SourceMapBuilder.AddInfo(Output.Output.Line, Output.Output.FirstNonSpace, node.SymbolInfo);
                 //Output.Comment(string.Join("; ", node.SymbolInfo.Select(item => item.StartLine + ":" + item.StartColumn)));

--- a/JSIL/JavascriptFormatter.cs
+++ b/JSIL/JavascriptFormatter.cs
@@ -168,7 +168,8 @@ namespace JSIL.Internal {
     }
 
     public class JavascriptFormatter {
-        public readonly PositionInfoTextWriter Output;
+        public readonly PositionInfoTextWriter OutputWithPositionInfo;
+        public readonly TextWriter Output;
         public readonly AssemblyManifest Manifest;
         public readonly ITypeInfoSource TypeInfo;
         public readonly AssemblyDefinition Assembly;
@@ -197,7 +198,16 @@ namespace JSIL.Internal {
             Configuration configuration,
             bool stubbed
         ) {
-            Output = new PositionInfoTextWriter(output);
+            if (sourceMapBuilder != null)
+            {
+                OutputWithPositionInfo = new PositionInfoTextWriter(output);
+                Output = OutputWithPositionInfo;
+            }
+            else
+            {
+                Output = output;
+            }
+
             SourceMapBuilder = sourceMapBuilder;
             TypeInfo = typeInfo;
             Manifest = manifest;

--- a/JSIL/JavascriptFormatter.cs
+++ b/JSIL/JavascriptFormatter.cs
@@ -168,12 +168,13 @@ namespace JSIL.Internal {
     }
 
     public class JavascriptFormatter {
-        public readonly TextWriter Output;
+        public readonly PositionInfoTextWriter Output;
         public readonly AssemblyManifest Manifest;
         public readonly ITypeInfoSource TypeInfo;
         public readonly AssemblyDefinition Assembly;
         public readonly AssemblyManifest.Token PrivateToken;
         public readonly Configuration Configuration;
+        public readonly SourceMapBuilder SourceMapBuilder;
 
         public MethodReference CurrentMethod = null;
 
@@ -191,12 +192,13 @@ namespace JSIL.Internal {
         };
 
         public JavascriptFormatter (
-            TextWriter output, ITypeInfoSource typeInfo, 
+            TextWriter output, SourceMapBuilder sourceMapBuilder, ITypeInfoSource typeInfo, 
             AssemblyManifest manifest, AssemblyDefinition assembly,
             Configuration configuration,
             bool stubbed
         ) {
-            Output = output;
+            Output = new PositionInfoTextWriter(output);
+            SourceMapBuilder = sourceMapBuilder;
             TypeInfo = typeInfo;
             Manifest = manifest;
             Assembly = assembly;
@@ -1297,6 +1299,69 @@ namespace JSIL.Internal {
             }
 
             RPar();
+        }
+    }
+
+    public class PositionInfoTextWriter : TextWriter
+    {
+        private readonly TextWriter _writer;
+        private int _newLineByteToCompare;
+        private int _line;
+        private int _column;
+        private long _position;
+        private int _firstNonSpace;
+
+
+        public PositionInfoTextWriter(TextWriter writer)
+        {
+            _writer = writer;
+        }
+
+        public override Encoding Encoding { get { return _writer.Encoding; } }
+
+        public int Line
+        {
+            get { return _line; }
+        }
+
+        public int Column
+        {
+            get { return _column; }
+        }
+
+        public long Position
+        {
+            get { return _position; }
+        }
+
+        public int FirstNonSpace
+        {
+            get { return _firstNonSpace < 0 ? _column : _firstNonSpace; }
+        }
+
+        public override void Write(char value)
+        {
+            if (_firstNonSpace < 0 && value != ' ')
+            {
+                _firstNonSpace = _column;
+            }
+
+            _position++;
+            _column++;
+
+            if (value == NewLine[_newLineByteToCompare])
+            {
+                _newLineByteToCompare ++;
+                if (_newLineByteToCompare == NewLine.Length)
+                {
+                    _newLineByteToCompare = 0;
+                    _column = 0;
+                    _firstNonSpace = -1;
+                    _line++;
+                }
+            }
+
+            _writer.Write(value);
         }
     }
 }

--- a/JSIL/SourceMapBuilder.cs
+++ b/JSIL/SourceMapBuilder.cs
@@ -9,9 +9,6 @@ namespace JSIL.Internal
 {
     public class SourceMapBuilder
     {
-        private readonly Dictionary<Tuple<long, long>, SequencePoint> CodeMap =
-            new Dictionary<Tuple<long, long>, SequencePoint>();
-
         private readonly List<Mapping> _mappings = new List<Mapping>(); 
 
         public void AddInfo(int genaratedLine, int generatedColumn, IEnumerable<SequencePoint> info)
@@ -30,7 +27,7 @@ namespace JSIL.Internal
         {
             // Translation of https://github.com/mozilla/source-map/
 
-            if (!CodeMap.Any())
+            if (!_mappings.Any())
             {
                 return false;
             }

--- a/JSIL/SourceMapBuilder.cs
+++ b/JSIL/SourceMapBuilder.cs
@@ -1,0 +1,280 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Mono.Cecil.Cil;
+
+namespace JSIL.Internal
+{
+    public class SourceMapBuilder
+    {
+        private readonly Dictionary<Tuple<long, long>, SequencePoint> CodeMap =
+            new Dictionary<Tuple<long, long>, SequencePoint>();
+
+        private readonly List<Mapping> _mappings = new List<Mapping>(); 
+
+        public void AddInfo(int genaratedLine, int generatedColumn, IEnumerable<SequencePoint> info)
+        {
+            var point = info != null ? info.FirstOrDefault() : null;
+            _mappings.Add(new Mapping(
+                genaratedLine + 1,
+                generatedColumn,
+                point == null ? -1 : point.StartLine,
+                point == null ? -1 : point.StartColumn - 1,
+                point == null ? null : point.Document.Url,
+                null));
+        }
+
+        public bool Build(string path, string sourceName)
+        {
+            // Translation of https://github.com/mozilla/source-map/
+
+            if (!CodeMap.Any())
+            {
+                return false;
+            }
+
+            var mappings = _mappings.OrderBy(item => item.GeneratedLine).ThenBy(item => item.GeneratedColumn).ToList();
+
+            var sources = new List<string>();
+            var names = new List<string>();
+            var previousGeneratedColumn = 0;
+            var previousGeneratedLine = 1;
+            var previousOriginalColumn = 0;
+            var previousOriginalLine = 0;
+            var previousName = 0;
+            var previousSource = 0;
+            StringBuilder result = new StringBuilder();
+
+            for (int i = 0; i < mappings.Count; i++)
+            {
+                var mapping = mappings[i];
+                if (mapping.Source != null && !sources.Contains(mapping.Source))
+                {
+                    sources.Add(mapping.Source);
+                }
+                if (mapping.Name != null && !names.Contains(mapping.Name))
+                {
+                    names.Add(mapping.Name);
+                }
+
+                if (mapping.GeneratedLine != previousGeneratedLine)
+                {
+                    previousGeneratedColumn = 0;
+                    while (mapping.GeneratedLine != previousGeneratedLine)
+                    {
+                        result.Append(';');
+                        previousGeneratedLine++;
+                    }
+                }
+                else
+                {
+                    if (i > 0)
+                    {
+                        if (mapping == mappings[i - 1])
+                        {
+                            continue;
+                        }
+                        result.Append(',');
+                    }
+                }
+
+                result.Append(Base64Vlq.Encode(mapping.GeneratedColumn - previousGeneratedColumn));
+                previousGeneratedColumn = mapping.GeneratedColumn;
+
+                if (mapping.Source != null)
+                {
+                    var sourceIdx = sources.IndexOf(mapping.Source);
+                    result.Append(Base64Vlq.Encode(sourceIdx - previousSource));
+                    previousSource = sourceIdx;
+
+                    // lines are stored 0-based in SourceMap spec version 3
+                    result.Append(Base64Vlq.Encode(mapping.OriginalLine  - 1 - previousOriginalLine));
+                    previousOriginalLine = mapping.OriginalLine - 1;
+
+                    result.Append(Base64Vlq.Encode(mapping.OriginalColumn - previousOriginalColumn));
+                    previousOriginalColumn = mapping.OriginalColumn;
+
+                    if (mapping.Name != null)
+                    {
+                        var nameIdx = names.IndexOf(mapping.Name);
+                        result.Append(Base64Vlq.Encode(nameIdx - previousName));
+                        previousName = nameIdx;
+                    }
+                }
+                //else
+                //{
+                ////IK: I'm not sure if we should do it? 
+                //    previousOriginalLine = 0;
+                //    previousOriginalColumn = 0;
+                //}
+            }
+
+            var sourceMap = new StringBuilder();
+            sourceMap.AppendLine("{");
+            sourceMap.AppendLine("\t\"version\" : 3,");
+            sourceMap.AppendLine(string.Format("\t\"file\" : \"{0}\",", sourceName));
+            sourceMap.AppendLine(string.Format("\t\"sourceRoot\" : \"{0}\",", new Uri(Path.GetFullPath(path))));
+            sourceMap.AppendLine(string.Format("\t\"sources\" : [{0}],", string.Join(", ", sources.Select(item => "\"" + MakeRelativePath(path, item) + "\""))));
+            sourceMap.AppendLine(string.Format("\t\"names\" : [{0}],", string.Join(", ", names.Select(item => "\"" + item + "\""))));
+            sourceMap.AppendLine(string.Format("\t\"mappings\" : \"{0}\"", result));
+            sourceMap.AppendLine("}");
+
+            using (var file = File.Create(Path.Combine(path, (sourceName + ".map").Replace(" ", ""))))
+            {
+                using (var tw = new StreamWriter(file))
+                {
+                    tw.Write(sourceMap.ToString());
+                    tw.Flush();
+
+                }
+            }
+            return true;
+        }
+
+        public static Uri MakeRelativePath(string fromPath, string toPath)
+        {
+            if (string.IsNullOrEmpty(fromPath)) throw new ArgumentNullException("fromPath");
+            if (string.IsNullOrEmpty(toPath)) throw new ArgumentNullException("toPath");
+
+            Uri fromUri = new Uri(Path.GetFullPath(fromPath));
+            Uri toUri = new Uri(Path.GetFullPath(toPath));
+
+            if (fromUri.Scheme != toUri.Scheme) { return toUri; } // path can't be made relative.
+
+            return fromUri.MakeRelativeUri(toUri);
+        }
+
+        private sealed class Mapping
+        {
+            public int GeneratedLine { get; private set; }
+            public int GeneratedColumn { get; private set; }
+
+            public int OriginalLine { get; private set; }
+            public int OriginalColumn { get; private set; }
+
+            public string Source { get; private set; }
+            public string Name { get; private set; }
+
+            public Mapping(int generatedLine, int generatedColumn, int originalLine, int originalColumn, string source, string name)
+            {
+                GeneratedLine = generatedLine;
+                GeneratedColumn = generatedColumn;
+                OriginalLine = originalLine;
+                OriginalColumn = originalColumn;
+                Source = source;
+                Name = name;
+            }
+
+            private bool Equals(Mapping other)
+            {
+                return GeneratedLine == other.GeneratedLine && GeneratedColumn == other.GeneratedColumn && OriginalLine == other.OriginalLine && OriginalColumn == other.OriginalColumn && string.Equals(Source, other.Source) && string.Equals(Name, other.Name);
+            }
+
+            public override bool Equals(object obj)
+            {
+                if (ReferenceEquals(null, obj)) return false;
+                if (ReferenceEquals(this, obj)) return true;
+                if (obj.GetType() != this.GetType()) return false;
+                return Equals((Mapping) obj);
+            }
+
+            public override int GetHashCode()
+            {
+                unchecked
+                {
+                    var hashCode = GeneratedLine.GetHashCode();
+                    hashCode = (hashCode*397) ^ GeneratedColumn.GetHashCode();
+                    hashCode = (hashCode*397) ^ OriginalLine.GetHashCode();
+                    hashCode = (hashCode*397) ^ OriginalColumn.GetHashCode();
+                    hashCode = (hashCode*397) ^ (Source != null ? Source.GetHashCode() : 0);
+                    hashCode = (hashCode*397) ^ (Name != null ? Name.GetHashCode() : 0);
+                    return hashCode;
+                }
+            }
+
+            public static bool operator ==(Mapping left, Mapping right)
+            {
+                return Equals(left, right);
+            }
+
+            public static bool operator !=(Mapping left, Mapping right)
+            {
+                return !Equals(left, right);
+            }
+        }
+
+        private static class Base64Vlq
+        {
+            private const string IntToCharMap = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+            // A single base 64 digit can contain 6 bits of data. For the base 64 variable
+            // length quantities we use in the source map spec, the first bit is the sign,
+            // the next four bits are the actual value, and the 6th bit is the
+            // continuation bit. The continuation bit tells us whether there are more
+            // digits in this value following this digit.
+            //
+            //   Continuation
+            //   |    Sign
+            //   |    |
+            //   V    V
+            //   101011
+
+            private const int VLQ_BASE_SHIFT = 5;
+
+            // binary: 100000
+            private const int VLQ_BASE = 1 << VLQ_BASE_SHIFT;
+
+            // binary: 011111
+            private const int VLQ_BASE_MASK = VLQ_BASE - 1;
+
+            // binary: 100000
+            private const int VLQ_CONTINUATION_BIT = VLQ_BASE;
+
+            /// <summary>
+            /// Converts from a two-complement value to a value where the sign bit is
+            /// placed in the least significant bit.For example, as decimals:
+            ///   1 becomes 2 (10 binary), -1 becomes 3 (11 binary)
+            ///   2 becomes 4 (100 binary), -2 becomes 5 (101 binary)
+            /// </summary>
+            private static uint ToVlqSigned(int aValue)
+            {
+                return (uint) (aValue < 0
+                    ? ((-aValue) << 1) + 1
+                    : (aValue << 1) + 0);
+            }
+
+            public static string Encode(int aValue)
+            {
+                var encoded = "";
+
+                var vlq = ToVlqSigned(aValue);
+
+                do
+                {
+                    var digit = vlq & VLQ_BASE_MASK;
+                    vlq >>= VLQ_BASE_SHIFT;
+                    if (vlq > 0)
+                    {
+                        // There are still more digits in this value, so we must make sure the
+                        // continuation bit is marked.
+                        digit |= VLQ_CONTINUATION_BIT;
+                    }
+                    encoded += EncodeDigit((int) digit);
+                } while (vlq > 0);
+
+                return encoded;
+            }
+
+            private static char EncodeDigit(int number)
+            {
+                if (number >= 0 && number < IntToCharMap.Length)
+                {
+                    return IntToCharMap[number];
+                }
+                throw new ArgumentException("Must be between 0 and 63: " + number);
+            }
+        }
+    }
+}

--- a/JSIL/SourceMapBuilder.cs
+++ b/JSIL/SourceMapBuilder.cs
@@ -155,7 +155,7 @@ namespace JSIL.Internal
             sourceMap.AppendLine(string.Format("\t\"mappings\" : \"{0}\"", result));
             sourceMap.AppendLine("}");
 
-            using (var file = File.Create(Path.Combine(path, (sourceName + ".map").Replace(" ", ""))))
+            using (var file = File.Create(GetFullMapPath(path, sourceName)))
             {
                 using (var tw = new StreamWriter(file))
                 {
@@ -309,6 +309,18 @@ namespace JSIL.Internal
                 }
                 throw new ArgumentException("Must be between 0 and 63: " + number);
             }
+        }
+
+        public void WriteSourceMapLink(Stream outputStream, string path, string sourceName)
+        {
+            var writer = new StreamWriter(outputStream);
+            writer.Write("//# sourceMappingURL=" + new Uri(GetFullMapPath(path, sourceName)));
+            writer.Flush();
+        }
+
+        private string GetFullMapPath(string path, string sourceName)
+        {
+            return Path.GetFullPath(Path.Combine(path, sourceName + ".map")).Replace(" ", "");
         }
     }
 }

--- a/JSIL/SourceMapBuilder.cs
+++ b/JSIL/SourceMapBuilder.cs
@@ -1,3 +1,42 @@
+/*
+ * Based on the Source Map library:
+ * https://github.com/mozilla/source-map
+
+ * Copyright 2011 Mozilla Foundation and contributors
+ * Licensed under the New BSD license. See LICENSE or:
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Based on the Base 64 VLQ implementation in Closure Compiler:
+ * https://code.google.com/p/closure-compiler/source/browse/trunk/src/com/google/debugging/sourcemap/Base64VLQ.java
+ *
+ * Copyright 2011 The Closure Compiler Authors. All rights reserved.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *  * Neither the name of Google Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -25,8 +64,6 @@ namespace JSIL.Internal
 
         public bool Build(string path, string sourceName)
         {
-            // Translation of https://github.com/mozilla/source-map/
-
             if (!_mappings.Any())
             {
                 return false;

--- a/JSIL/TranslationResult.cs
+++ b/JSIL/TranslationResult.cs
@@ -133,7 +133,7 @@ namespace JSIL {
                         {
                             using (var tw = new StreamWriter(fs))
                             {
-                                tw.Write("//# sourceMappingURL=" + new Uri(Path.Combine(path, (kvp.Key + ".map").Replace(" ", ""))));
+                                tw.Write("//# sourceMappingURL=" + new Uri(Path.GetFullPath(Path.Combine(path, (kvp.Key + ".map").Replace(" ", "")))));
                             }
                         }
                     }

--- a/JSIL/TranslationResult.cs
+++ b/JSIL/TranslationResult.cs
@@ -133,7 +133,7 @@ namespace JSIL {
                         {
                             using (var tw = new StreamWriter(fs))
                             {
-                                tw.Write("//# sourceMappingURL=" + (kvp.Key +".map").Replace(" ", ""));
+                                tw.Write("//# sourceMappingURL=" + new Uri(Path.Combine(path, (kvp.Key + ".map").Replace(" ", ""))));
                             }
                         }
                     }


### PR DESCRIPTION
Looks like I was able add some initial support of Source maps (#76). For now it was done not very clean and mostly hackish, but it already works in Chrome/IE/Visual Studio.
To enable their generation, user need add `BuildSourceMap : true` key in .jsilconfig.