### PR TITLE
EliminateTemporaries don't treat JSIndexerExpression as immutable

### DIFF
--- a/JSIL/Transforms/StaticAnalysis/EliminateSingleUseTemporaries.cs
+++ b/JSIL/Transforms/StaticAnalysis/EliminateSingleUseTemporaries.cs
@@ -72,18 +72,6 @@ namespace JSIL.Transforms {
                 }
             }
 
-            // Handle special cases where our interpretation of 'constant' needs to be more flexible
-            {
-                var ie = source as JSIndexerExpression;
-                if (ie != null) {
-                    if (
-                        IsEffectivelyConstant(target, ie.Target) &&
-                        IsEffectivelyConstant(target, ie.Index)
-                    )
-                        return true;
-                }
-            }
-
             {
                 var ae = source as JSArrayExpression;
                 if (

--- a/Tests/SimpleTestCasesForTranslatedBcl/Stack.cs
+++ b/Tests/SimpleTestCasesForTranslatedBcl/Stack.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Collections.Generic;
+
+public static class Program
+{
+    public static void Main(string[] args)
+    {
+        var stack = new Stack<string>();
+        stack.Push("test");
+        Console.WriteLine(stack.Pop());
+    }
+}

--- a/Tests/SimpleTests.csproj
+++ b/Tests/SimpleTests.csproj
@@ -128,6 +128,7 @@
     <None Include="SimpleTestCases\Issue743.cs" />
     <None Include="SimpleTestCases\UInt64_Issue855.cs" />
     <None Include="SimpleTestCases\StringFromCtor.cs" />
+    <None Include="SimpleTestCasesForTranslatedBcl\Stack.cs" />
     <Compile Include="SimpleTests.cs" />
     <None Include="SimpleTestCases\BaseAutoProperties.cs" />
     <None Include="SimpleTestCases\OverloadedVirtualMethods.cs" />


### PR DESCRIPTION
Fix for #868. Test added.