### PR TITLE
Create decimal literals through decimal constructor.

### DIFF
--- a/JSIL/AST/JSLiteralTypes.cs
+++ b/JSIL/AST/JSLiteralTypes.cs
@@ -244,6 +244,20 @@ namespace JSIL.Ast {
         }
     }
 
+    public class JSDecimalLiteral : JSLiteralBase<Decimal>
+    {
+        public JSDecimalLiteral(decimal value)
+            : base(value)
+        {
+        }
+
+        public override TypeReference GetActualType(TypeSystem typeSystem)
+        {
+            return new TypeReference(typeSystem.Double.Namespace, "Decimal", typeSystem.Double.Module,
+                typeSystem.Double.Scope, true);
+        }
+    }
+
     public class JSNumberLiteral : JSLiteralBase<double> {
         public readonly Type OriginalType;
 
@@ -260,8 +274,6 @@ namespace JSIL.Ast {
                         return typeSystem.Single;
                     case "System.Double":
                         return typeSystem.Double;
-                    case "System.Decimal":
-                        return new TypeReference(typeSystem.Double.Namespace, "Decimal", typeSystem.Double.Module, typeSystem.Double.Scope, true);
                     default:
                         throw new NotImplementedException(String.Format(
                             "Unsupported number literal type: {0}",

--- a/JSIL/AST/JSNodeTypes.cs
+++ b/JSIL/AST/JSNodeTypes.cs
@@ -494,8 +494,8 @@ namespace JSIL.Ast {
             return new JSNumberLiteral(value, typeof(double));
         }
 
-        public static JSNumberLiteral New (decimal value) {
-            return new JSNumberLiteral((double)value, typeof(decimal));
+        public static JSDecimalLiteral New (decimal value) {
+            return new JSDecimalLiteral(value);
         }
 
         public static JSDefaultValueLiteral DefaultValue (TypeReference type) {

--- a/JSIL/JavascriptAstEmitter.cs
+++ b/JSIL/JavascriptAstEmitter.cs
@@ -992,6 +992,11 @@ namespace JSIL {
             }
         }
 
+        public void VisitNode(JSDecimalLiteral number)
+        {
+            VisitNode(new JSNewExpression(number.GetActualType(TypeSystem), null, null, JSLiteral.New((double) number.Value)));
+        }
+
         public void VisitNode (JSBooleanLiteral b) {
             Output.Value(b.Value);
         }


### PR DESCRIPTION
Use constructor to create decimal literals (#871). When we implement full decimal support we should change this, as we still load value through conversion to double.