### PR TITLE
Delagate fixes

### DIFF
--- a/JSIL.Libraries/Includes/Bootstrap/Core/Classes/System.Delegate.js
+++ b/JSIL.Libraries/Includes/Bootstrap/Core/Classes/System.Delegate.js
@@ -109,7 +109,7 @@ JSIL.ImplementExternals("System.Delegate", function ($) {
       if (typeof (delegatePublicInterface.New) !== "function")
         JSIL.Host.abort(new Error("Invalid delegate type"));
 
-      return delegatePublicInterface.New(firstArgument, null, new JSIL.MethodInfoMethodPointerInfo(method));
+      return delegatePublicInterface.New(firstArgument, null, JSIL.MethodPointerInfo.FromMethodInfo(method));
     }
   );
 

--- a/JSIL.Libraries/Sources/JSIL.Core.js
+++ b/JSIL.Libraries/Sources/JSIL.Core.js
@@ -10759,7 +10759,7 @@ JSIL.MethodPointerInfo = function(typeObject, name, signature, isStatic, isVirtu
 JSIL.MethodInfoMethodPointerInfo = function(methodInfo) {
   var signature = methodInfo._data.signature;
   var genericArgs = null;
-  if (signature.openSignature !== null) {
+  if (JSIL.IsArray(signature.genericArgumentValues)) {
     genericArgs = signature.genericArgumentValues;
     signature = signature.openSignature;
   }

--- a/JSIL.Libraries/Sources/JSIL.Core.js
+++ b/JSIL.Libraries/Sources/JSIL.Core.js
@@ -10756,7 +10756,7 @@ JSIL.MethodPointerInfo = function(typeObject, name, signature, isStatic, isVirtu
   this.NameWithGenericSuffix = useGenericSuffix ? (name + "$b" + this.MethodGenericParameters.length) : name;
 }
 
-JSIL.MethodInfoMethodPointerInfo = function(methodInfo) {
+JSIL.MethodPointerInfo.FromMethodInfo = function (methodInfo) {
   var signature = methodInfo._data.signature;
   var genericArgs = null;
   if (JSIL.IsArray(signature.genericArgumentValues)) {
@@ -10764,7 +10764,7 @@ JSIL.MethodInfoMethodPointerInfo = function(methodInfo) {
     signature = signature.openSignature;
   }
 
-  JSIL.MethodPointerInfo.call(this,
+  var methodPointerInfo = new JSIL.MethodPointerInfo(
     methodInfo._typeObject.__PublicInterface__,
     methodInfo._descriptor.Name,
     signature,
@@ -10772,11 +10772,10 @@ JSIL.MethodInfoMethodPointerInfo = function(methodInfo) {
     methodInfo._descriptor.Virtual,
     genericArgs);
 
-  this.MethodInfo = methodInfo;
-  this.MethodInfoResolved = true;
+  methodPointerInfo.MethodInfo = methodInfo;
+  methodPointerInfo.MethodInfoResolved = true;
+  return methodPointerInfo;
 }
-
-JSIL.MethodInfoMethodPointerInfo.prototype = JSIL.MethodPointerInfo.prototype;
 
 JSIL.MethodPointerInfo.prototype.resolveMethodInfo = function () {
   if (!this.MethodInfoResolved) {

--- a/JSIL.Libraries/Sources/JSIL.Core.js
+++ b/JSIL.Libraries/Sources/JSIL.Core.js
@@ -9469,36 +9469,22 @@ JSIL.MakeDelegate = function (fullName, isPublic, genericArguments, methodSignat
           JSIL.RuntimeError("Single delegate argument passed to Delegate.New, but types don't match");
       }
 
+      var resultDelegate;
       if (method === null && methodPointerInfo instanceof JSIL.MethodPointerInfo) {
-        if (methodPointerInfo.IsStatic) {
-          if (object === null) {
-            method = function() {
-              return methodPointerInfo.Signature.CallStatic.apply(methodPointerInfo.Signature, [methodPointerInfo.TypeObject, methodPointerInfo.NameWithGenericSuffix, methodPointerInfo.MethodGenericParameters].concat(Array.prototype.slice.call(arguments)));
-            }
-          } else {
-            method = function() {
-              return methodPointerInfo.Signature.CallStatic.apply(methodPointerInfo.Signature, [methodPointerInfo.TypeObject, methodPointerInfo.NameWithGenericSuffix, methodPointerInfo.MethodGenericParameters, object].concat(Array.prototype.slice.call(arguments)));
-            }
-          }
-        } else if (!methodPointerInfo.IsVirtual) {
-          method = function () { return methodPointerInfo.Signature.Call.apply(methodPointerInfo.Signature, [methodPointerInfo.TypeObject.prototype, methodPointerInfo.NameWithGenericSuffix, methodPointerInfo.MethodGenericParameters, object].concat(Array.prototype.slice.call(arguments))); };
-        } else if (!methodPointerInfo.TypeObject.__Type__.IsInterface) {
-          method = function () { return methodPointerInfo.Signature.CallVirtual.apply(methodPointerInfo.Signature, [methodPointerInfo.NameWithGenericSuffix, methodPointerInfo.MethodGenericParameters, object].concat(Array.prototype.slice.call(arguments))); };
-        } else {
-          method = function () { return methodPointerInfo.Signature.CallVirtual.apply(methodPointerInfo.Signature, [methodPointerInfo.TypeObject[methodPointerInfo.NameWithGenericSuffix], methodPointerInfo.MethodGenericParameters, object].concat(Array.prototype.slice.call(arguments))); };
+        method = methodPointerInfo.createInvocationFunction(object);
+        resultDelegate = method;
+      } else {
+        if (typeof (method) !== "function") {
+          JSIL.RuntimeError("Non-function passed to Delegate.New");
         }
+
+        if (method.__IsMembrane__)
+          method = method.__Unwrap__();
+
+        resultDelegate = function Delegate_Invoke() {
+          return method.apply(object, arguments);
+        };
       }
-
-      if (typeof (method) !== "function") {
-        JSIL.RuntimeError("Non-function passed to Delegate.New");
-      }
-
-      if (method.__IsMembrane__)
-        method = method.__Unwrap__();
-
-      var resultDelegate = function Delegate_Invoke () {
-        return method.apply(object, arguments);
-      };
 
       JSIL.SetValueProperty(resultDelegate, "__ThisType__", this.__Type__);
       JSIL.SetValueProperty(resultDelegate, "toString", toStringImpl);
@@ -10773,3 +10759,160 @@ JSIL.MethodPointerInfo = function(typeObject, name, signature, isStatic, isVirtu
 JSIL.MethodPointerInfo.prototype.resolveMethodInfo = function () {
   return JSIL.GetMethodInfo(this.TypeObject, this.Name, this.Signature, this.IsStatic, this.MethodGenericParameters);
 }
+
+JSIL.MethodPointerInfo.prototype.createInvocationFunction = function(thisObject) {
+  var argsCount = JSIL.IsArray(this.Signature.argumentTypes) ? this.Signature.argumentTypes.length : 0;
+
+  if (thisObject === null) {
+    if (this.IsStatic) {
+      return JSIL.MethodPointerInfo.$createStaticInvocation(argsCount, false)(this);
+    } else if (!this.IsVirtual) {
+      return JSIL.MethodPointerInfo.$createInstanceInvocation(argsCount, false)(this);
+    } else if (!this.TypeObject.__Type__.IsInterface) {
+      return JSIL.MethodPointerInfo.$createVirtualInvocation(argsCount, false)(this);
+    } else {
+      return JSIL.MethodPointerInfo.$createVirtualInterfaceInvocation(argsCount, false)(this);
+    }
+  } else {
+    if (this.IsStatic) {
+      return JSIL.MethodPointerInfo.$createStaticInvocation(argsCount, true)(this, thisObject);
+    } else if (!this.IsVirtual) {
+      return JSIL.MethodPointerInfo.$createInstanceInvocation(argsCount, true)(this, thisObject);
+    } else if (!this.TypeObject.__Type__.IsInterface) {
+      return JSIL.MethodPointerInfo.$createVirtualInvocation(argsCount, true)(this, thisObject);
+    } else {
+      return JSIL.MethodPointerInfo.$createVirtualInterfaceInvocation(argsCount, true)(this, thisObject);
+    }
+  }
+}
+
+JSIL.MethodPointerInfo.$createStaticInvocation = function (argsCount, saveThis)
+{
+  var key = "InvokeStatic" + (saveThis ? "Attached" : "") + argsCount;
+
+  if (!(key in JSIL.MethodPointerInfo)) {
+    var innerArgs = [];
+    var innerBody = [];
+
+    innerBody.push("//# sourceURL=jsil://closure/JSIL.MethodPointerInfo." + key + "\r\n");
+    innerBody.push("\"use strict\";\r\n");
+
+    if (saveThis) {
+      innerBody.push("return methodPointer.Signature.CallStatic(methodPointer.TypeObject, methodPointer.NameWithGenericSuffix, methodPointer.MethodGenericParameters, arg0");
+    } else {
+      innerBody.push("return methodPointer.Signature.CallStatic(methodPointer.TypeObject, methodPointer.NameWithGenericSuffix, methodPointer.MethodGenericParameters");
+    }
+    for (var i = (saveThis ? 1 : 0); i < argsCount; i++) {
+      innerArgs.push("arg" + i);
+      innerBody.push(", arg" + i);
+    }
+    innerBody.push(")");
+
+    var outerBody = "return function "+ key +"(" + innerArgs.join(", ") + ") {" + innerBody.join("") + "};";
+    if (saveThis) {
+      JSIL.MethodPointerInfo[key] = new Function("methodPointer", "arg0", outerBody);
+    } else {
+      JSIL.MethodPointerInfo[key] = new Function("methodPointer", outerBody);
+    }
+  }
+
+  return JSIL.MethodPointerInfo[key];
+}
+
+
+JSIL.MethodPointerInfo.$createInstanceInvocation = function (argsCount, saveThis) {
+  var key = "InvokeInstance" + (saveThis ? "" : "Detached") + argsCount;
+
+  if (!(key in JSIL.MethodPointerInfo)) {
+    var innerArgs = [];
+    var innerBody = [];
+
+    innerBody.push("//# sourceURL=jsil://closure/JSIL.MethodPointerInfo." + key + "\r\n");
+    innerBody.push("\"use strict\";\r\n");
+
+    innerBody.push("return methodPointer.Signature.Call(methodPointer.TypeObject.prototype, methodPointer.NameWithGenericSuffix, methodPointer.MethodGenericParameters, thisObject");
+
+    if (!saveThis) {
+      innerArgs.push("thisObject");
+    }
+
+    for (var i = 0; i < argsCount; i++) {
+      innerArgs.push("arg" + i);
+      innerBody.push(", arg" + i);
+    }
+    innerBody.push(")");
+
+    var outerBody = "return function " + key + "(" + innerArgs.join(", ") + ") {" + innerBody.join("") + "};";
+    if (saveThis) {
+      JSIL.MethodPointerInfo[key] = new Function("methodPointer", "thisObject", outerBody);
+    } else {
+      JSIL.MethodPointerInfo[key] = new Function("methodPointer", outerBody);
+    }
+  }
+
+  return JSIL.MethodPointerInfo[key];
+}
+
+JSIL.MethodPointerInfo.$createVirtualInvocation = function (argsCount, saveThis) {
+  var key = "InvokeVirtual" + (saveThis ? "" : "Detached") + argsCount;
+
+  if (!(key in JSIL.MethodPointerInfo)) {
+    var innerArgs = [];
+    var innerBody = [];
+
+    innerBody.push("//# sourceURL=jsil://closure/JSIL.MethodPointerInfo." + key + "\r\n");
+    innerBody.push("\"use strict\";\r\n");
+
+    innerBody.push("return methodPointer.Signature.CallVirtual(methodPointer.NameWithGenericSuffix, methodPointer.MethodGenericParameters, thisObject");
+    if (!saveThis) {
+      innerArgs.push("thisObject");
+    }
+    for (var i = 0; i < argsCount; i++) {
+      innerArgs.push("arg" + i);
+      innerBody.push(", arg" + i);
+    }
+    innerBody.push(")");
+
+    var outerBody = "return function " + key + "(" + innerArgs.join(", ") + ") {" + innerBody.join("") + "};";
+    if (saveThis) {
+      JSIL.MethodPointerInfo[key] = new Function("methodPointer", "thisObject", outerBody);
+    } else {
+      JSIL.MethodPointerInfo[key] = new Function("methodPointer", outerBody);
+    }
+  }
+
+  return JSIL.MethodPointerInfo[key];
+}
+
+JSIL.MethodPointerInfo.$createVirtualInterfaceInvocation = function (argsCount, saveThis) {
+  var key = "InvokeVirtualInterface" + (saveThis ? "" : "Detached") + argsCount;
+
+  if (!(key in JSIL.MethodPointerInfo)) {
+    var innerArgs = [];
+    var innerBody = [];
+
+    innerBody.push("//# sourceURL=jsil://closure/JSIL.MethodPointerInfo." + key + "\r\n");
+    innerBody.push("\"use strict\";\r\n");
+
+    innerBody.push("return methodPointer.Signature.CallVirtual(methodPointer.TypeObject[methodPointer.NameWithGenericSuffix], methodPointer.MethodGenericParameters, thisObject");
+    if (!saveThis) {
+      innerArgs.push("thisObject");
+    }
+    for (var i = 0; i < argsCount; i++) {
+      innerArgs.push("arg" + i);
+      innerBody.push(", arg" + i);
+    }
+    innerBody.push(")");
+
+    var outerBody = "return function " + key + "(" + innerArgs.join(", ") + ") {" + innerBody.join("") + "};";
+    if (saveThis) {
+      JSIL.MethodPointerInfo[key] = new Function("methodPointer", "thisObject", outerBody);
+    } else {
+      JSIL.MethodPointerInfo[key] = new Function("methodPointer", outerBody);
+    }
+  }
+
+  return JSIL.MethodPointerInfo[key];
+}
+
+

--- a/JSIL.Libraries/Sources/JSIL.Core.js
+++ b/JSIL.Libraries/Sources/JSIL.Core.js
@@ -9483,7 +9483,7 @@ JSIL.MakeDelegate = function (fullName, isPublic, genericArguments, methodSignat
         } else if (!methodPointerInfo.IsVirtual) {
           method = function () { return methodPointerInfo.Signature.Call.apply(methodPointerInfo.Signature, [methodPointerInfo.TypeObject.prototype, methodPointerInfo.NameWithGenericSuffix, methodPointerInfo.MethodGenericParameters, object].concat(Array.prototype.slice.call(arguments))); };
         } else if (!methodPointerInfo.TypeObject.__Type__.IsInterface) {
-          method = function () { methodPointerInfo.Signature.CallVirtual.apply(methodPointerInfo.Signature, [methodPointerInfo.NameWithGenericSuffix, methodPointerInfo.MethodGenericParameters, object].concat(Array.prototype.slice.call(arguments))); };
+          method = function () { return methodPointerInfo.Signature.CallVirtual.apply(methodPointerInfo.Signature, [methodPointerInfo.NameWithGenericSuffix, methodPointerInfo.MethodGenericParameters, object].concat(Array.prototype.slice.call(arguments))); };
         } else {
           method = function () { return methodPointerInfo.Signature.CallVirtual.apply(methodPointerInfo.Signature, [methodPointerInfo.TypeObject[methodPointerInfo.NameWithGenericSuffix], methodPointerInfo.MethodGenericParameters, object].concat(Array.prototype.slice.call(arguments))); };
         }

--- a/JSIL/AST/JSExpressionTypes.cs
+++ b/JSIL/AST/JSExpressionTypes.cs
@@ -811,6 +811,35 @@ namespace JSIL.Ast {
         }
     }
 
+    public class JSMethodPointerInfoExpression : JSMethod
+    {
+        public JSMethodPointerInfoExpression(
+            MethodReference reference, MethodInfo method, MethodTypeFactory methodTypes, bool isVirtual,
+            IEnumerable<TypeReference> genericArguments = null)
+            : base(reference, method, methodTypes, genericArguments)
+        {
+            IsVirtual = isVirtual;
+        }
+
+        public override bool HasGlobalStateDependency
+        {
+            get
+            {
+                return false;
+            }
+        }
+
+        public bool IsVirtual { get; private set; }
+
+        public override bool IsConstant
+        {
+            get
+            {
+                return true;
+            }
+        }
+    }
+
     public class JSPublicInterfaceOfExpression : JSExpression {
         public JSPublicInterfaceOfExpression (JSExpression inner)
             : base(inner) {
@@ -3253,23 +3282,6 @@ namespace JSIL.Ast {
 
         public override TypeReference GetActualType (TypeSystem typeSystem) {
             return ResultType;
-        }
-    }
-
-    public class JSDeferredExpression : JSExpression {
-        public JSDeferredExpression(JSExpression innerExpression)
-            : base(new [] { innerExpression})
-        {
-        }
-
-        public JSExpression InnerExpression
-        {
-            get { return (JSExpression)Children.First(); }
-        }
-
-        public override TypeReference GetActualType(TypeSystem typeSystem)
-        {
-            return typeSystem.Object;
         }
     }
 

--- a/JSIL/ILBlockTranslator.cs
+++ b/JSIL/ILBlockTranslator.cs
@@ -3186,10 +3186,7 @@ namespace JSIL {
                     if (ma.IsStatic) {
                         if (methodMember == null)
                             throw new InvalidDataException("Static invocation without a method");
-
-                        thisArg = new JSType(methodMember.Reference.DeclaringType);
-                    } else if (ma.IsVirtual)
-                        methodRef = new JSDotExpression(thisArg, methodMember);
+                    } 
                 }
             }
 

--- a/JSIL/Transforms/CacheSignatures.cs
+++ b/JSIL/Transforms/CacheSignatures.cs
@@ -258,6 +258,11 @@ namespace JSIL.Transforms {
             CacheSignature(methodOf.Reference, methodOf.Method.Signature, false);
         }
 
+        public void VisitNode(JSMethodPointerInfoExpression methodOf)
+        {
+            CacheSignature(methodOf.Reference, methodOf.Method.Signature, false);
+        }
+
         public void VisitNode (JSInvocationExpression invocation) {
             var jsm = invocation.JSMethod;
             MethodInfo method = null;

--- a/Tests/SimpleTestCases/DelegateOverload_Issue806.cs
+++ b/Tests/SimpleTestCases/DelegateOverload_Issue806.cs
@@ -4,14 +4,68 @@ public static class Program
 {
     public static void Main(string[] args)
     {
+        var obj = new Derived();
+
+        Console.WriteLine("**Static**");
         Action<Derived> dDerived = Method;
         Action<Base> dBase = Method;
         Action<IInterface> dIInterface = Method;
+        Action<Derived> dGenericDerived = Method<object>;
+        Action<Base> dGenericBase = Method<object>;
 
-        var obj = new Derived();
         dIInterface(obj);
         dBase(obj);
         dDerived(obj);
+        dGenericDerived(obj);
+        dGenericBase(obj);
+
+        Console.WriteLine("**Non-Virtual**");
+        var classObj = new MethodHolder();
+        dDerived = classObj.Method;
+        dBase = classObj.Method;
+        dIInterface = classObj.Method;
+        dGenericDerived = classObj.Method<object>;
+        dGenericBase = classObj.Method<object>;
+
+        dIInterface(obj);
+        dBase(obj);
+        dDerived(obj);
+        dGenericDerived(obj);
+        dGenericBase(obj);
+
+        Console.WriteLine("**Virtual**");
+        var vObj = new VirtualMethodHolder();
+        dDerived = vObj.Method;
+        dBase = vObj.Method;
+        dIInterface = vObj.Method;
+        dGenericDerived = vObj.Method<object>;
+        dGenericBase = vObj.Method<object>;
+
+        dIInterface(obj);
+        dBase(obj);
+        dDerived(obj);
+        dGenericDerived(obj);
+        dGenericBase(obj);
+
+        Console.WriteLine("**Interface**");
+        var iObj = GetInterfaceHolder();
+        dDerived = iObj.Method;
+        dBase = iObj.Method;
+        dIInterface = iObj.Method;
+        dGenericDerived = iObj.Method<object>;
+        dGenericBase = iObj.Method<object>;
+
+        dIInterface(obj);
+        // Doesn't work due #892
+        //dBase(obj);
+        //dDerived(obj);
+        //dGenericDerived(obj);
+        //dGenericBase(obj);
+    }
+
+    public static IMethodHolder GetInterfaceHolder()
+    {
+        return new MethodHolder();
     }
 
     public static void Method(Base input)
@@ -28,6 +82,16 @@ public static class Program
     {
         Console.WriteLine("Derived");
     }
+
+    public static void Method<T>(Derived input)
+    {
+        Console.WriteLine("GenericDerived");
+    }
+
+    public static void Method<T>(Base input)
+    {
+        Console.WriteLine("GenericBase");
+    }
 }
 
 
@@ -41,4 +105,69 @@ public class Derived : Base
 
 public interface IInterface
 {
+}
+
+public interface IMethodHolder
+{
+    void Method(Base input);
+    void Method(IInterface input);
+    void Method(Derived input);
+    void Method<T>(Derived input);
+    void Method<T>(Base input);
+}
+
+public class MethodHolder : IMethodHolder
+{
+    public void Method(Base input)
+    {
+        Console.WriteLine("Base");
+    }
+
+    public void Method(IInterface input)
+    {
+        Console.WriteLine("IInterface");
+    }
+
+    public void Method(Derived input)
+    {
+        Console.WriteLine("Derived");
+    }
+
+    public void Method<T>(Derived input)
+    {
+        Console.WriteLine("GenericDerived");
+    }
+
+    public void Method<T>(Base input)
+    {
+        Console.WriteLine("GenericBase");
+    }
+}
+
+public class VirtualMethodHolder : IMethodHolder
+{
+    public virtual void Method(Base input)
+    {
+        Console.WriteLine("Base");
+    }
+
+    public virtual void Method(IInterface input)
+    {
+        Console.WriteLine("IInterface");
+    }
+
+    public virtual void Method(Derived input)
+    {
+        Console.WriteLine("Derived");
+    }
+
+    public virtual void Method<T>(Derived input)
+    {
+        Console.WriteLine("GenericDerived");
+    }
+
+    public virtual void Method<T>(Base input)
+    {
+        Console.WriteLine("GenericBase");
+    }
 }

--- a/Tests/SimpleTestCases/Delegate_Issue875.cs
+++ b/Tests/SimpleTestCases/Delegate_Issue875.cs
@@ -1,0 +1,25 @@
+using System;
+
+public static class Program
+{
+    public static void Main(string[] args)
+    {
+        var Data = new Data();
+        Action<string> TestAction = Data.SetValue;
+        TestAction("Hello World");
+        Console.WriteLine(Data.Name);
+    }
+}
+
+public sealed class Data
+{
+    public string Name { get; set; }
+}
+
+public static class Helper
+{
+    public static void SetValue(this Data Self, string Value)
+    {
+        Self.Name = Value;
+    }
+}

--- a/Tests/SimpleTestCases/Delegate_Issue880.cs
+++ b/Tests/SimpleTestCases/Delegate_Issue880.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Collections.Generic;
+
+public static class Program
+{
+    public static void Main(string[] args)
+    {
+        var List = new List<Action>();
+
+        foreach (var Index in new int[] { 1, 2, 3 })
+        {
+            var Local = Index;
+
+            List.Add(() => Console.WriteLine("Delegate Index(" + Index + ") vs Local(" + Local + ")"));
+        }
+
+        foreach (var Action in List)
+            Action();
+    }
+}

--- a/Tests/SimpleTests.csproj
+++ b/Tests/SimpleTests.csproj
@@ -248,6 +248,8 @@
     <None Include="SimpleTestCases\ListContains.cs" />
     <None Include="SimpleTestCases\ListIndexOf.cs" />
     <None Include="SimpleTestCases\ListInsert.cs" />
+    <None Include="SimpleTestCases\Delegate_Issue880.cs" />
+    <None Include="SimpleTestCases\Delegate_Issue875.cs" />
     <None Include="SimpleTestCases\StructGenericParameterReferenceEquality.cs" />
     <None Include="SimpleTestCases\ArrayListIndexer.cs" />
     <None Include="SimpleTestCases\ListIList.cs" />


### PR DESCRIPTION
Here is new delegate invocation implementation.
Now I store all required info (method owner, name, signature, if call is virtual) in JSIL.MethodPointerInfo, and use appropriate call through signature in JS part.

It fixes both #876 and #880.

Future work options (we may discuss it here, but will post them in separate PR):
1. Create methods in runtime to exclude `.apply` usage in delegate invocation (at least don't use it twice).
2. Probably move delegates created in run-time from MethodInfo to the same approach. MethodInfo invocation probably also worth to change same way to unify codebase.

Note: Looks like Mono was updated on Travis, and two tests fails now. It is not related to this PR.