### PR TITLE
Correct implementation of GetHashCode for struct types.

### DIFF
--- a/JSIL.Libraries/Includes/Core/Types/Classes/System.ValueType.js
+++ b/JSIL.Libraries/Includes/Core/Types/Classes/System.ValueType.js
@@ -1,8 +1,99 @@
 ﻿JSIL.MakeClass("System.Object", "System.ValueType", true, [], function ($) {
-    $.Method({ Static: false, Public: true }, "Object.Equals",
-      new JSIL.MethodSignature(System.Boolean, [System.Object]),
-      function (rhs) {
-          return JSIL.StructEquals(this, rhs);
+  var makeComparerCore = function(typeObject, context, body) {
+    var fields = JSIL.GetFieldList(typeObject);
+
+    if (context.prototype.__CompareMembers__) {
+      context.comparer = context.prototype.__CompareMembers__;
+      body.push("  return context.comparer(lhs, rhs);");
+    } else {
+      for (var i = 0; i < fields.length; i++) {
+        var field = fields[i];
+        var fieldType = field.type;
+
+        if (fieldType.__IsNumeric__ || fieldType.__IsEnum__) {
+          body.push("  if (" + JSIL.FormatMemberAccess("lhs", field.name) + " !== " + JSIL.FormatMemberAccess("rhs", field.name) + ")");
+        } else {
+          body.push("  if (!JSIL.ObjectEquals(" + JSIL.FormatMemberAccess("lhs", field.name) + ", " + JSIL.FormatMemberAccess("rhs", field.name) + "))");
+        }
+
+        body.push("    return false;");
       }
+
+      body.push("  return true;");
+    }
+  };
+
+  var makeStructComparer = function (typeObject, publicInterface) {
+    var prototype = publicInterface.prototype;
+    var context = {
+      prototype: prototype
+    };
+
+    var body = [];
+
+    makeComparerCore(typeObject, context, body);
+
+    return JSIL.CreateNamedFunction(
+      typeObject.__FullName__ + ".StructComparer",
+      ["lhs", "rhs"],
+      body.join("\r\n")
     );
+  };
+
+  var structEquals = function Struct_Equals(lhs, rhs) {
+    if (lhs === rhs)
+      return true;
+
+    if ((rhs === null) || (rhs === undefined))
+      return false;
+
+    var thisType = lhs.__ThisType__;
+    var comparer = thisType.__Comparer__;
+    if (comparer === $jsilcore.FunctionNotInitialized)
+      comparer = thisType.__Comparer__ = makeStructComparer(thisType, thisType.__PublicInterface__);
+
+    return comparer(lhs, rhs);
+  };
+
+  var makeGetHashCode = function (typeObject, publicInterface) {
+    var body = [];
+
+    var fields = JSIL.GetFieldList(typeObject);
+    body.push("  var hash = 17;");
+    for (var i = 0; i < fields.length; i++) {
+      var field = fields[i];
+      var fieldAccess = JSIL.FormatMemberAccess("thisReference", field.name);
+      body.push("  hash =( Math.imul(hash * 23) + ((" + fieldAccess + "=== null ? 0 : " + fieldAccess + ") | 0)) | 0;");
+    }
+    body.push("  return hash;");
+
+    return JSIL.CreateNamedFunction(
+      typeObject.__FullName__ + ".GetHashCode",
+      ["thisReference"],
+      body.join("\r\n")
+    );
+  };
+
+  var structGetHashCode = function Struct_GetHashCode(thisReference) {
+    var thisType = thisReference.__ThisType__;
+    var getHashCode = thisType.__GetHashCode__;
+    if (getHashCode === $jsilcore.FunctionNotInitialized)
+      getHashCode = thisType.__GetHashCode__ = makeGetHashCode(thisType, thisType.__PublicInterface__);
+
+    return getHashCode(thisReference);
+  };
+
+  $.Method({ Static: false, Public: true }, "Object.Equals",
+    new JSIL.MethodSignature($.Boolean, [System.Object]),
+    function(rhs) {
+      return structEquals(this, rhs);
+    }
+  );
+
+  $.Method({ Static: false, Public: true }, "GetHashCode",
+    new JSIL.MethodSignature($.Int32, []),
+    function() {
+      return structGetHashCode(this);
+    }
+  );
 });

--- a/JSIL.Libraries/Includes/Core/Types/Classes/System.ValueType.js
+++ b/JSIL.Libraries/Includes/Core/Types/Classes/System.ValueType.js
@@ -63,7 +63,7 @@
     for (var i = 0; i < fields.length; i++) {
       var field = fields[i];
       var fieldAccess = JSIL.FormatMemberAccess("thisReference", field.name);
-      body.push("  hash =( Math.imul(hash * 23) + ((" + fieldAccess + "=== null ? 0 : " + fieldAccess + ") | 0)) | 0;");
+      body.push("  hash =( Math.imul(hash * 23) + ((" + fieldAccess + " === null ? 17 : JSIL.ObjectHashCode(" + fieldAccess + ", true, $jsilcore.System.Object)) | 0)) | 0;");
     }
     body.push("  return hash;");
 

--- a/Tests/SimpleTestCases/StructHashCode.cs
+++ b/Tests/SimpleTestCases/StructHashCode.cs
@@ -8,15 +8,15 @@ public static class Program {
         var s2 = new Pair<int, int>(1, 1);
         var s3 = new Pair<int, int>(1, 2);
 
-        var obj1 = new ClassWithCustomHashCode(1);
-        var obj2 = new ClassWithCustomHashCode(2);
+        var obj1 = new object();
+        var obj2 = new object();
 
-        var s4 = new Pair<int, object>(1, obj1);
-        var s5 = new Pair<int, object>(1, obj1);
-        var s6 = new Pair<int, object>(1, obj2);
-        var s7 = new Pair<int, object>(1, obj2);
-        var s8 = new Pair<int, object>(1, null);
-        var s9 = new Pair<int, object>(1, null);
+        var s4 = new Pair<object, object>(null, obj1);
+        var s5 = new Pair<object, object>(null, obj1);
+        var s6 = new Pair<object, object>(null, obj2);
+        var s7 = new Pair<object, object>(null, obj2);
+        var s8 = new Pair<object, object>(null, null);
+        var s9 = new Pair<object, object>(null, null);
 
         Console.WriteLine(s1.GetHashCode() == s2.GetHashCode() ? "true" : "false");
         Console.WriteLine(s1.GetHashCode() == s3.GetHashCode() ? "true" : "false");
@@ -27,21 +27,6 @@ public static class Program {
 
         Console.WriteLine(s6.GetHashCode() == s7.GetHashCode() ? "true" : "false");
         Console.WriteLine(s8.GetHashCode() == s9.GetHashCode() ? "true" : "false");
-    }
-}
-
-public class ClassWithCustomHashCode
-{
-    private int _hashCode;
-
-    public ClassWithCustomHashCode(int hashCode)
-    {
-        _hashCode = hashCode;
-    }
-
-    public override int GetHashCode()
-    {
-        return _hashCode;
     }
 }
 

--- a/Tests/SimpleTestCases/StructHashCode.cs
+++ b/Tests/SimpleTestCases/StructHashCode.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Collections.Generic;
+
+public static class Program {
+    public static void Main (string[] args)
+    {
+        var s1 = new Pair<int, int>(1, 1);
+        var s2 = new Pair<int, int>(1, 1);
+        var s3 = new Pair<int, int>(1, 2);
+
+        var obj1 = new ClassWithCustomHashCode(1);
+        var obj2 = new ClassWithCustomHashCode(2);
+
+        var s4 = new Pair<int, object>(1, obj1);
+        var s5 = new Pair<int, object>(1, obj1);
+        var s6 = new Pair<int, object>(1, obj2);
+        var s7 = new Pair<int, object>(1, obj2);
+        var s8 = new Pair<int, object>(1, null);
+        var s9 = new Pair<int, object>(1, null);
+
+        Console.WriteLine(s1.GetHashCode() == s2.GetHashCode() ? "true" : "false");
+        Console.WriteLine(s1.GetHashCode() == s3.GetHashCode() ? "true" : "false");
+
+        Console.WriteLine(s4.GetHashCode() == s5.GetHashCode() ? "true" : "false");
+        Console.WriteLine(s4.GetHashCode() == s6.GetHashCode() ? "true" : "false");
+        Console.WriteLine(s4.GetHashCode() == s8.GetHashCode() ? "true" : "false");
+
+        Console.WriteLine(s6.GetHashCode() == s7.GetHashCode() ? "true" : "false");
+        Console.WriteLine(s8.GetHashCode() == s9.GetHashCode() ? "true" : "false");
+    }
+}
+
+public class ClassWithCustomHashCode
+{
+    private int _hashCode;
+
+    public ClassWithCustomHashCode(int hashCode)
+    {
+        _hashCode = hashCode;
+    }
+
+    public override int GetHashCode()
+    {
+        return _hashCode;
+    }
+}
+
+public struct Pair<T, K>
+{
+    private T _f1;
+    private K _f2;
+
+    public Pair(T f1, K f2)
+    {
+        _f1 = f1;
+        _f2 = f2;
+    }
+}

--- a/Tests/SimpleTests.csproj
+++ b/Tests/SimpleTests.csproj
@@ -239,6 +239,7 @@
     <None Include="SimpleTestCases\ArrayLongLength.cs" />
     <None Include="SimpleTestCases\ArrayResize.cs" />
     <None Include="SimpleTestCases\StringContains.cs" />
+    <None Include="SimpleTestCases\StructHashCode.cs" />
     <None Include="SimpleTestCases\StringSubstring.cs" />
     <None Include="SimpleTestCases\GetTypeOfBoolean.cs" />
     <None Include="SimpleTestCases\Int32CompareExchange.cs" />


### PR DESCRIPTION
Struct types should calculate their hash code based on their fields. Here it is implemented and test added.