### PR TITLE
Implement String.Join(string, IEnumerable<string>)

### DIFF
--- a/Proxies/String.cs
+++ b/Proxies/String.cs
@@ -99,6 +99,12 @@ namespace JSIL.Proxies {
             throw new NotImplementedException();
         }
 
+        [JSIsPure]
+        [JSReplacement("JSIL.JoinEnumerable($separator, $values)")]
+        public static string Join (string separator, IEnumerable<string> values) {
+            throw new NotImplementedException();
+        }
+
         [JSChangeName("length")]
         [JSAlwaysAccessAsProperty]
         [JSNeverReplace]

--- a/Tests/SimpleTestCases/StringJoinEnumerable.cs
+++ b/Tests/SimpleTestCases/StringJoinEnumerable.cs
@@ -5,6 +5,9 @@ static class Program {
     public static void Main () {
         IEnumerable<A> items = new List<A>() { new A("Foo"), new A("Bar"), new A("Baz"), new A("Qux") };
         Console.WriteLine(string.Join("; ", items));
+
+        IEnumerable<string> strings = new List<string> { "Foo", "Bar", "Baz", "Qux" };
+        Console.WriteLine(string.Join("; ", strings));
     }
 }
 


### PR DESCRIPTION
This String.Join overload was not declared, although JSIL.JoinEnumerable
would already do the job if asked. This commit connects the two and
updates the existing test to cover the IEnumerable<String> case as well.
The other String.Join overloads are untouched.