### PR TITLE
Define Enumerable.{Zip,Skip,Last}

### DIFF
--- a/JSIL.Libraries/Includes/Bootstrap/Linq/Classes/System.Linq.Enumerable.js
+++ b/JSIL.Libraries/Includes/Bootstrap/Linq/Classes/System.Linq.Enumerable.js
@@ -169,6 +169,89 @@
         }
       );
 
+      var lastImpl = function (T, enumerable, predicate) {
+        var IList = System.Collections.Generic.IList$b1.Of(T);
+        var list = IList.$As(enumerable);
+        if (list !== null) {
+          var item = IList.get_Item;
+          var useLength = (typeof list.Count) == 'undefined';
+          if ((useLength && list.length === 0) || list.Count === 0)
+            return { success: false };
+          var len = useLength ? list.length : list.Count;
+          if (arguments.length >= 3) {
+            for (var i = len - 1; i >= 0; i--) {
+              var val = item.Call(list, [], i);
+              if (predicate(val))
+                return {
+                  success: true,
+                  value: val
+                }
+            }
+            return { success: false };
+          } else {
+            return {
+              success: true,
+              value: item.Call(list, [], len - 1)
+            };
+          }
+        }
+        var e = JSIL.GetEnumerator(enumerable);
+
+        var moveNext = $jsilcore.System.Collections.IEnumerator.MoveNext;
+        var getCurrent = $jsilcore.System.Collections.IEnumerator.get_Current;
+
+        try {
+          var acceptedVal;
+          var val;
+          while (moveNext.Call(e)) {
+              val = getCurrent.Call(e);
+              if (arguments.length >= 3) {
+                if (predicate(val))
+                  acceptedVal = val;
+              } else
+                acceptedVal = val;
+          }
+          if (typeof acceptedVal !== 'undefined')
+            return { success: true, value: acceptedVal };
+          return { success: false };
+        } finally {
+          JSIL.Dispose(e);
+        }
+      };
+
+      $.Method({ Static: true, Public: true }, "Last",
+        new JSIL.MethodSignature(
+          "!!0",
+          [$jsilcore.TypeRef("System.Collections.Generic.IEnumerable`1",
+            ["!!0"])],
+          ["TSource"]
+        ),
+        function (T, enumerable) {
+          var result = lastImpl(T, enumerable);
+          if (!result.success)
+              throw new System.InvalidOperationException("Sequence contains no elements");
+
+          return result.value;
+        }
+      );
+
+      $.Method({ Static: true, Public: true }, "Last",
+        new JSIL.MethodSignature(
+          "!!0",
+          [$jsilcore.TypeRef("System.Collections.Generic.IEnumerable`1", ["!!0"]),
+           $jsilcore.TypeRef("System.Func`2", ["!!0", $.Boolean])],
+          ["TSource"]
+        ),
+        function (T, enumerable, predicate) {
+            var result = lastImpl(T, enumerable, predicate);
+            if (!result.success)
+                throw new System.InvalidOperationException("Sequence contains no elements");
+
+            return result.value;
+        }
+      );
+
+
       $.Method({ Static: true, Public: true }, "Select",
         new JSIL.MethodSignature(
           $jsilcore.TypeRef("System.Collections.Generic.IEnumerable`1", ["!!1"]),

--- a/JSIL.Libraries/Includes/Bootstrap/Linq/Classes/System.Linq.Enumerable.js
+++ b/JSIL.Libraries/Includes/Bootstrap/Linq/Classes/System.Linq.Enumerable.js
@@ -256,6 +256,46 @@
         }
       );
 
+      $.Method({ Static: true, Public: true }, "Skip",
+        new JSIL.MethodSignature(
+          $jsilcore.TypeRef("System.Collections.Generic.IEnumerable`1",
+            ["!!0"]),
+          [
+            $jsilcore.TypeRef("System.Collections.Generic.IEnumerable`1",
+              ["!!0"]),
+            "System.Int32"
+          ],
+          ["TSource"]
+        ),
+        function (TSource, source, count) {
+          var state = {};
+
+          var tIEnumerator = System.Collections.Generic.IEnumerator$b1.Of(TSource);
+          var moveNext = System.Collections.IEnumerator.MoveNext;
+          var get_Current = tIEnumerator.get_Current;
+
+          return new (JSIL.AbstractEnumerable.Of(TSource))(
+            function getNext(result) {
+                if (!state.ready) {
+                  for (var i = 0; i < count; i++)
+                    moveNext.Call(state.enumerator);
+                  state.ready = true;
+                }
+                var ok = moveNext.Call(state.enumerator);
+                if (ok)
+                    result.set(get_Current.Call(state.enumerator));
+                return ok;
+            },
+            function reset() {
+                state.enumerator = JSIL.GetEnumerator(source, TSource);
+            },
+            function dispose() {
+                JSIL.Dispose(state.enumerator);
+            }
+          );
+        }
+      );
+
       $.Method({ Static: true, Public: true }, "Contains",
         (new JSIL.MethodSignature($.Boolean, [$jsilcore.TypeRef("System.Collections.Generic.IEnumerable`1", ["!!0"]), "!!0"], ["TSource"])),
         function Contains$b1(T, source, item) {

--- a/JSIL.Libraries/Includes/Bootstrap/Linq/Classes/System.Linq.Enumerable.js
+++ b/JSIL.Libraries/Includes/Bootstrap/Linq/Classes/System.Linq.Enumerable.js
@@ -332,6 +332,50 @@
         }
       );
 
+      $.Method({ Static: true, Public: true }, "Zip",
+        new JSIL.MethodSignature(
+          $jsilcore.TypeRef("System.Collections.Generic.IEnumerable`1",
+            ["!!2"]),
+          [
+            $jsilcore.TypeRef("System.Collections.Generic.IEnumerable`1",
+              ["!!0"]),
+            $jsilcore.TypeRef("System.Collections.Generic.IEnumerable`1",
+              ["!!1"]),
+            $jsilcore.TypeRef("System.Func`3", ["!!0", "!!1", "!!2"])
+          ],
+          ["TFirst", "TSecond", "TResult"]
+        ),
+        function (TFirst, TSecond, TResult, first, second, combiner) {
+          var state = {};
+
+          var tIEnumerator1 = System.Collections.Generic.IEnumerator$b1.Of(TFirst);
+          var tIEnumerator2 = System.Collections.Generic.IEnumerator$b1.Of(TSecond);
+          var moveNext = System.Collections.IEnumerator.MoveNext;
+          var get_Current1 = tIEnumerator1.get_Current;
+          var get_Current2 = tIEnumerator2.get_Current;
+
+          return new (JSIL.AbstractEnumerable.Of(TResult))(
+            function getNext(result) {
+                var ok1 = moveNext.Call(state.enumerator1);
+                var ok2 = moveNext.Call(state.enumerator2);
+                if (ok1 && ok2)
+                    result.set(combiner(get_Current1.Call(state.enumerator1),
+                                get_Current2.Call(state.enumerator2)));
+
+                return ok1 && ok2;
+            },
+            function reset() {
+                state.enumerator1 = JSIL.GetEnumerator(first, TFirst);
+                state.enumerator2 = JSIL.GetEnumerator(second, TSecond);
+            },
+            function dispose() {
+                JSIL.Dispose(state.enumerator1);
+                JSIL.Dispose(state.enumerator2);
+            }
+          );
+        }
+      );
+
       $.Method({ Static: true, Public: true }, "ToArray",
         new JSIL.MethodSignature($jsilcore.TypeRef("System.Array", ["!!0"]), [$jsilcore.TypeRef("System.Collections.Generic.IEnumerable`1", ["!!0"])], ["TSource"]),
         function (T, enumerable) {

--- a/Tests/SimpleTestCases/EnumerableLast.cs
+++ b/Tests/SimpleTestCases/EnumerableLast.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+public static class Program {
+    public static void Main () {
+        var ints = new[] { 1, 2, 3, 4 };
+
+        Console.WriteLine(ints.Last());
+
+        Console.WriteLine(ints.Last((i) => i < 3));
+
+        // Test the non-IList path
+        Console.WriteLine(ints.Skip(1).Last());
+
+        Console.WriteLine(ints.Skip(1).Last((i) => i < 3));
+    }
+}

--- a/Tests/SimpleTestCases/EnumerableSkip.cs
+++ b/Tests/SimpleTestCases/EnumerableSkip.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+public static class Program {
+    public static void Main () {
+        var ints = new[] { 1, 2, 3, 4 };
+
+        foreach (var i in ints.Skip(2))
+            Console.WriteLine(i);
+
+    }
+}

--- a/Tests/SimpleTestCases/EnumerableZip.cs
+++ b/Tests/SimpleTestCases/EnumerableZip.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+public static class Program {
+    public static void Main () {
+        var ints1 = new[] { 1, 2, 3, 4 };
+        var ints2 = new List<int> { 5, 6, 7 };
+
+        foreach (var prod in ints1.Zip(ints2, (l, r) => l * r ))
+            Console.WriteLine(prod);
+
+    }
+}

--- a/Tests/SimpleTests.csproj
+++ b/Tests/SimpleTests.csproj
@@ -339,6 +339,7 @@
     <None Include="SimpleTestCases\StringFromCharArray.cs" />
     <None Include="SimpleTestCases\EnumerableCast.cs" />
     <None Include="SimpleTestCases\EnumerableToList.cs" />
+    <None Include="SimpleTestCases\EnumerableZip.cs" />
     <None Include="SimpleTestCases\Issue176.cs" />
     <None Include="SimpleTestCases\Issue118_1.fs" />
     <None Include="SimpleTestCases\EnumerableElementAt.cs" />

--- a/Tests/SimpleTests.csproj
+++ b/Tests/SimpleTests.csproj
@@ -301,6 +301,7 @@
     <None Include="SimpleTestCases\ParameterNamedThis.cs" />
     <None Include="SimpleTestCases\EnumInPlaceAdd.cs" />
     <None Include="SimpleTestCases\EnumerableStringMethod.cs" />
+    <None Include="SimpleTestCases\EnumerableSkip.cs" />
     <None Include="SimpleTestCases\UnboxBoolean.cs" />
     <None Include="SimpleTestCases\MathIntrinsics.cs" />
     <None Include="SimpleTestCases\StringSplitDefaultSeparators.cs" />

--- a/Tests/SimpleTests.csproj
+++ b/Tests/SimpleTests.csproj
@@ -198,6 +198,7 @@
     <None Include="SimpleTestCases\IEEERemainder.cs" />
     <None Include="SimpleTestCases\StringFormatAlignment.cs" />
     <None Include="SimpleTestCases\EnumerableFirst.cs" />
+    <None Include="SimpleTestCases\EnumerableLast.cs" />
     <None Include="SimpleTestCases\Issue245.cs" />
     <None Include="SimpleTestCases\ListIndexOfEnum.cs" />
     <None Include="SimpleTestCases\ArrayICollection.cs" />


### PR DESCRIPTION
Each of these methods is implemented and a test case added. Enumerable.Last has a special optimised case for lists, as the native implementation does, and the others produce a JSIL.AbstractEnumerable.