### PR TITLE
Travis fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ before_cache:
   - mv "/tmp/JSIL Tests" /tmp/JSIL_Tests  
   
 after_script:
+  - export BUILD_FINISH_TIME=$(date --utc +%Y%m%d_%H%M%SZ)
   - true && [ ! "$JSIL_STORAGE_FOLDER" ] && export JSIL_STORAGE_FOLDER=JSIL
   - true && [ ! "$JSIL_STORAGE_TAG" ] && export BUILD_TAG=TRAVIS_${TRAVIS_JOB_NUMBER##*.} || export BUILD_TAG=$JSIL_STORAGE_TAG
   - export CACHE_PATH=$BUILD_TAG/$TRAVIS_BUILD_NUMBER-$TRAVIS_COMMIT
@@ -31,9 +32,9 @@ after_script:
   - export MKDIR_COMMAND="curl -H \"Authorization:OAuth $JSIL_STORAGE_KEY\" -L -X MKCOL \"https://webdav.yandex.com/$JSIL_STORAGE_FOLDER/_\""  
   - true && [ "$JSIL_STORAGE_KEY" ] && eval ${MKDIR_COMMAND/_/$BUILD_TAG}
   - true && [ "$JSIL_STORAGE_KEY" ] && eval ${MKDIR_COMMAND/_/$CACHE_PATH}
-  - true && [ "$JSIL_STORAGE_KEY" ] && zip -3 -r -q - /tmp/JSIL_Tests | eval ${UPLOAD_COMMAND/_/$CACHE_PATH/compilecache.zip}
-  - true && [ "$JSIL_STORAGE_KEY" ] && [ ! "$SKIP_BINARIES" ] && zip -3 -r -q - bin Libraries | eval ${UPLOAD_COMMAND/_/$CACHE_PATH/binaries.zip}
-  - true && [ "$JSIL_STORAGE_KEY" ] && zip -3 -r -q - -@ Libraries test_runner.html < <(find . -name *.out) | eval ${UPLOAD_COMMAND/_/$CACHE_PATH/tests.zip}
+  - true && [ "$JSIL_STORAGE_KEY" ] && zip -3 -r -q - /tmp/JSIL_Tests | eval ${UPLOAD_COMMAND/_/$CACHE_PATH/compilecache_$BUILD_FINISH_TIME.zip}
+  - true && [ "$JSIL_STORAGE_KEY" ] && [ ! "$SKIP_BINARIES" ] && zip -3 -r -q - bin Libraries | eval ${UPLOAD_COMMAND/_/$CACHE_PATH/binaries_$BUILD_FINISH_TIME.zip}
+  - true && [ "$JSIL_STORAGE_KEY" ] && zip -3 -r -q - -@ Libraries test_runner.html < <(find . -name *.out) | eval ${UPLOAD_COMMAND/_/$CACHE_PATH/tests_$BUILD_FINISH_TIME.zip}
   
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,12 +36,14 @@ after_script:
   
 env:
   global:
-    - JsilUseAppDomainsInTest=true
     - NODEJS_VERSION=0.10
   matrix:
     - TestRun=JSIL.Tests.DeadCodeEliminationTest,JSIL.Tests.APITests,JSIL.Tests.AnalysisTests,JSIL.Tests.ComparisonTests,JSIL.Tests.ConfigurationTests,JSIL.Tests.DependencyTests,JSIL.Tests.FailingTests,JSIL.Tests.FormattingTests,JSIL.Tests.GenericsTests,JSIL.Tests.MetadataTests,JSIL.Tests.PerformanceTests,JSIL.Tests.TypeInformationTests,JSIL.Tests.UnsafeTests,JSIL.Tests.VerbatimTests,JSIL.Tests.XMLTests,JSIL.Tests.ThreadingTests
       JSIL_STORAGE_TAG=misc-tests
-    - TestRun=JSIL.SimpleTests.SimpleTests,JSIL.SimpleTests.SimpleTestCasesForStubbedBcl
+    - TestRun=JSIL.SimpleTests.SimpleTests
+      JSIL_STORAGE_TAG=simple-tests
+      SKIP_BINARIES=TRUE
+    - TestRun=JSIL.SimpleTests.SimpleTestCasesForStubbedBcl
       JSIL_STORAGE_TAG=stubbed-tests
       SKIP_BINARIES=TRUE
     - TestRun=JSIL.SimpleTests.SimpleTestCasesForTranslatedBcl

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,10 +24,11 @@ before_cache:
   - mv "/tmp/JSIL Tests" /tmp/JSIL_Tests  
   
 after_script:
+  - true && [ ! "$JSIL_STORAGE_FOLDER" ] && export JSIL_STORAGE_FOLDER=JSIL
   - true && [ ! "$JSIL_STORAGE_TAG" ] && export BUILD_TAG=TRAVIS_${TRAVIS_JOB_NUMBER##*.} || export BUILD_TAG=$JSIL_STORAGE_TAG
   - export CACHE_PATH=$BUILD_TAG/$TRAVIS_BUILD_NUMBER-$TRAVIS_COMMIT
-  - export UPLOAD_COMMAND="curl -H \"Authorization:OAuth $JSIL_STORAGE_KEY\" -L -T - \"https://webdav.yandex.com/JSIL/_\""  
-  - export MKDIR_COMMAND="curl -H \"Authorization:OAuth $JSIL_STORAGE_KEY\" -L -X MKCOL \"https://webdav.yandex.com/JSIL/_\""  
+  - export UPLOAD_COMMAND="curl -H \"Authorization:OAuth $JSIL_STORAGE_KEY\" -L -T - \"https://webdav.yandex.com/$JSIL_STORAGE_FOLDER/_\""  
+  - export MKDIR_COMMAND="curl -H \"Authorization:OAuth $JSIL_STORAGE_KEY\" -L -X MKCOL \"https://webdav.yandex.com/$JSIL_STORAGE_FOLDER/_\""  
   - true && [ "$JSIL_STORAGE_KEY" ] && eval ${MKDIR_COMMAND/_/$BUILD_TAG}
   - true && [ "$JSIL_STORAGE_KEY" ] && eval ${MKDIR_COMMAND/_/$CACHE_PATH}
   - true && [ "$JSIL_STORAGE_KEY" ] && zip -3 -r -q - /tmp/JSIL_Tests | eval ${UPLOAD_COMMAND/_/$CACHE_PATH/compilecache.zip}

--- a/Tests/EvaluatorPool.cs
+++ b/Tests/EvaluatorPool.cs
@@ -158,10 +158,20 @@ namespace JSIL.Tests {
             var stdout = Process.StandardOutput.ReadToEndAsync();
             var stderr = Process.StandardError.ReadToEndAsync();
 
-            _StdOut = await stdout;
-            _StdErr = await stderr;
+            _StdOut = FixEncodingIfNeed(await stdout);
+            _StdErr = FixEncodingIfNeed(await stderr);
 
             signal.Set();
+        }
+
+        private static string FixEncodingIfNeed(string input)
+        {
+            if (input!= null && input.StartsWith("獪"))
+            {
+                return Encoding.UTF8.GetString(Encoding.Unicode.GetBytes(input));
+            }
+
+            return input;
         }
 
         /// <summary>


### PR DESCRIPTION
1. Disabled using of AppDomains in tests. Looks like it much more stable without them.
2. Changed artifacts upload script - it is possible to configure upload folder name now, use build date suffix for uploaded artifacts to preserve artifacts of rerun.

With this change, I can configure uploading build artifacts to my Yandex.Drive (publicly accessible https://yadi.sk/d/YnPDF_zfkzAbH). @kg, are you OK for me to update SQ/JSIL Travis-CI configuration after this PR will be merged?