### PR TITLE
JSIL.MakeTypeAlias check for same assembly prototype

### DIFF
--- a/JSIL.Libraries/Sources/JSIL.Core.js
+++ b/JSIL.Libraries/Sources/JSIL.Core.js
@@ -5338,7 +5338,8 @@ JSIL.MakeTypeAlias = function (sourceAssembly, fullName) {
     }
   );
 
-  if (sourceAssembly.__AssemblyId__ === context.__AssemblyId__) {
+  // BCL assemblies are created with $jsilcore in prototype  but different __AssemblyId__
+  if (sourceAssembly.__AssemblyId__ === context.__AssemblyId__ || sourceAssembly.isPrototypeOf(context)) {
     // HACK: This is a recursive type alias, so don't define the name alias.
     // We still want to leave the typesByName logic above intact since the two aliases have separate assembly
     //  objects, and thus separate typesByName lists, despite sharing an assembly id.


### PR DESCRIPTION
Fix for #936.