### PR TITLE
Web workers support

### DIFF
--- a/JSIL.Libraries/JSIL.Libraries.csproj
+++ b/JSIL.Libraries/JSIL.Libraries.csproj
@@ -287,6 +287,8 @@
     <Content Include="Sources\gamepad.js" />
     <Content Include="Sources\JSIL.Bootstrap.Dynamic.js" />
     <Content Include="Sources\JSIL.Bootstrap.Text.js" />
+    <Content Include="Sources\JSIL.WebWorker.js" />
+    <Content Include="Sources\JSIL.WebWorker.Loaders.js" />
     <Content Include="Sources\StubbedBCL\JSIL.IO.js" />
     <Content Include="Sources\StubbedBCL\JSIL.XML.js" />
     <Content Include="Sources\TranslatedBCL\JSIL.Bootstrap.js" />

--- a/JSIL.Libraries/Sources/JSIL.WebWorker.Loaders.js
+++ b/JSIL.Libraries/Sources/JSIL.WebWorker.Loaders.js
@@ -1,0 +1,13 @@
+var assetLoaders = {
+  "Library": function loadLibrary (filename, data, onError, onDoneLoading, state) {
+    var uri = jsilConfig.libraryRoot + filename;
+    importScripts(uri);
+  },
+  "Script": function loadScript (filename, data, onError, onDoneLoading, state) {
+    var uri = jsilConfig.scriptRoot + filename;
+    importScripts(uri);
+  },
+};
+
+function initAssetLoaders () {
+};

--- a/JSIL.Libraries/Sources/JSIL.WebWorker.js
+++ b/JSIL.Libraries/Sources/JSIL.WebWorker.js
@@ -1,0 +1,103 @@
+"use strict";
+
+JSIL.DeclareNamespace("JSIL.WebWorker", false);
+
+JSIL.WebWorker.StdOutService = function () {
+};
+
+JSIL.WebWorker.StdOutService.prototype.write = function (text) {
+  postMessage("output " + text);
+};
+
+
+JSIL.WebWorker.StdErrService = function () {
+};
+
+JSIL.WebWorker.StdErrService.prototype.write = function (text) {
+  var trimmed = String(text).trim();
+  if (trimmed[trimmed.length - 1] === "\n") {
+    text = trimmed.substr(0, trimmed.length - 1);
+  }
+
+ postMessage("error " + text);
+};
+
+(function () {
+  JSIL.Host.registerServices({
+    stdout: new JSIL.WebWorker.StdOutService(),
+    stderr: new JSIL.WebWorker.StdErrService()
+  });
+})();
+
+function reportException (e) {
+  var stack = "";
+  try {
+    stack = e.stack || "";
+  } catch (ex) {
+    stack = "";
+  }
+
+  JSIL.Host.logWriteLine("// EXCEPTION:");
+  JSIL.Host.logWriteLine(String(e));
+  if (stack.length > 0) {
+    JSIL.Host.logWriteLine("// STACK:");
+    JSIL.Host.logWriteLine(stack);
+  }
+  JSIL.Host.logWriteLine("// ENDEXCEPTION");
+
+  throw e;
+};
+
+function loadAssets (assets) {
+  for (var i = 0, l = assets.length; i < l; i++) {
+    var assetSpec = assets[i];
+  
+    var assetType = assetSpec[0];
+    var assetPath = assetSpec[1];
+    var assetData = assetSpec[2] || null;
+
+    var assetLoader = assetLoaders[assetType];
+
+    assetLoader(assetPath, assetData);
+  }
+};
+  
+// onLoad will be called from the worker.
+var onLoad = function  () {
+  initAssetLoaders();
+
+  var seenFilenames = {};
+
+  var pushAsset = function (assetSpec) {
+    var filename = assetSpec[1];
+    if (seenFilenames[filename])
+      return;
+
+    seenFilenames[filename] = true;
+    allAssetsToLoad.push(assetSpec);
+  }
+
+  var allAssetsToLoad = [];
+
+  if (typeof (assetsToLoad) !== "undefined") {
+    for (var i = 0, l = assetsToLoad.length; i < l; i++)
+      pushAsset(assetsToLoad[i]);
+  }
+
+  if (typeof (contentManifest) === "object") {
+    for (var k in contentManifest) {
+      var subManifest = contentManifest[k];
+
+      for (var i = 0, l = subManifest.length; i < l; i++)
+        pushAsset(subManifest[i]);
+
+    }
+  }
+
+  loadAssets(allAssetsToLoad);
+    JSIL.Initialize();
+    JSIL.Host.runInitCallbacks();
+    if (typeof (runMain) === "function") {
+        runMain();
+    }
+};

--- a/JSIL.Libraries/Sources/JSIL.js
+++ b/JSIL.Libraries/Sources/JSIL.js
@@ -31,15 +31,15 @@
     globalNamespace.jsilConfig = {};
 
   if (typeof (globalNamespace.contentManifest) !== "object")
-    globalNamespace.contentManifest = {}; 
-})(this);
+      globalNamespace.contentManifest = {
+          "JSIL": []
+      };
 
-contentManifest["JSIL"] = [];
-
-var $jsilloaderstate = {
-  environment: null,
-  loadFailures: []
-};
+  globalNamespace.$jsilloaderstate = {
+    environment: null,
+    loadFailures: []
+  };
+})(typeof(self) !== "undefined" ? self : this);
 
 (function loadJSIL (config) {
     function getLibraryPrefix(config) {

--- a/JSIL.Libraries/Sources/JSIL.js
+++ b/JSIL.Libraries/Sources/JSIL.js
@@ -42,6 +42,15 @@ var $jsilloaderstate = {
 };
 
 (function loadJSIL (config) {
+    function getLibraryPrefix(config) {
+        if (config.bclMode === "translated") {
+            return "TranslatedBCL/";
+        } else if (config.bclMode === "stubbed") {
+            return "StubbedBCL/";
+        }
+
+            return "IgnoredBCL/";
+    }
 
   function Environment_Browser (config) {
     var self = this;
@@ -67,14 +76,7 @@ var $jsilloaderstate = {
       }
     }
 
-    var libraryPrefix;
-    if (config.bclMode === "translated") {
-      libraryPrefix = "TranslatedBCL/";
-    } else if (config.bclMode === "stubbed") {
-      libraryPrefix = "StubbedBCL/";
-    } else {
-      libraryPrefix = "IgnoredBCL/";
-    }
+    var libraryPrefix = getLibraryPrefix(config);
 
     contentManifest["JSIL"].push(["Library", "JSIL.Storage.js"]);
     contentManifest["JSIL"].push(["Library", libraryPrefix + "JSIL.IO.js"]);
@@ -130,14 +132,7 @@ var $jsilloaderstate = {
     var self = this;
     this.config = config;
 
-    var libraryPrefix;
-    if (config.bclMode === "translated") {
-      libraryPrefix = "TranslatedBCL/";
-    } else if (config.bclMode === "stubbed") {
-      libraryPrefix = "StubbedBCL/";
-    } else {
-      libraryPrefix = "IgnoredBCL/";
-    }
+    var libraryPrefix = getLibraryPrefix(config);
 
     contentManifest["JSIL"].push(["Library", "JSIL.Storage.js"]);
     contentManifest["JSIL"].push(["Library", libraryPrefix + "JSIL.IO.js"]);
@@ -159,6 +154,31 @@ var $jsilloaderstate = {
   Environment_SpidermonkeyShell.prototype.loadEnvironmentScripts = function () {
     this.loadScript(libraryRoot + "JSIL.Shell.js");
     this.loadScript(libraryRoot + "JSIL.Shell.Loaders.js");
+  };
+
+
+  function Environment_WebWorker(config) {
+      var self = this;
+      this.config = config;
+
+      var libraryPrefix = getLibraryPrefix(config);
+
+      contentManifest["JSIL"].push(["Library", "JSIL.Storage.js"]);
+      contentManifest["JSIL"].push(["Library", libraryPrefix + "JSIL.IO.js"]);
+      contentManifest["JSIL"].push(["Library", libraryPrefix + "JSIL.XML.js"]);
+  };
+
+  Environment_WebWorker.prototype.getUserSetting = function (key) {
+      return false;
+  };
+
+  Environment_WebWorker.prototype.loadScript = function (uri) {
+      importScripts(uri);
+  };
+
+  Environment_WebWorker.prototype.loadEnvironmentScripts = function () {
+      this.loadScript(libraryRoot + "JSIL.WebWorker.js");
+      this.loadScript(libraryRoot + "JSIL.WebWorker.Loaders.js");
   };
 
   var priorModule = JSIL.GlobalNamespace.Module;
@@ -202,7 +222,8 @@ var $jsilloaderstate = {
 
   var environments = {
     "browser": Environment_Browser,
-    "spidermonkey_shell": Environment_SpidermonkeyShell
+    "spidermonkey_shell": Environment_SpidermonkeyShell,
+    "webworker": Environment_WebWorker
   }
 
   if (!config.environment) {


### PR DESCRIPTION
Here is basic implementation of WebWorker environment support based on #656.
Also there JSIL.js was changed a little bit for better compatibility with JS packers (tested with browserify). When it pack files, each file is placed inside function which is called on newly created object. After it, resolving of global scope through this doesn't work anymore. However, in both browser and webworker global scope could be accessed with `self` property. So, if self is defined, it is used as global scope reference.