### PR TITLE
Assembly wrap in IIFE with references

### DIFF
--- a/JSIL/Configuration.cs
+++ b/JSIL/Configuration.cs
@@ -122,6 +122,7 @@ namespace JSIL.Translator {
         public string AssemblyCollectionName;
         public string EmitterFactoryName;
         public bool? BuildSourceMap;
+        public bool? InlineAssemblyReferences;
 
         public double? FrameworkVersion;
 
@@ -166,6 +167,9 @@ namespace JSIL.Translator {
 
             if (BuildSourceMap != null)
                 result.BuildSourceMap = BuildSourceMap;
+
+            if (InlineAssemblyReferences != null)
+                result.InlineAssemblyReferences = InlineAssemblyReferences;
 
             Assemblies.MergeInto(result.Assemblies);
             CodeGenerator.MergeInto(result.CodeGenerator);


### PR DESCRIPTION
Implemented wrapping assembly in IIFE with references to other used assemblies (so assembly and manifest could be produced independently).
This feature is hidden under configuration parameter `InlineAssemblyReferences`.

This PR should open path for reusing of single-assembly translation, so it is possible to build some mechanics for translating one assembly per JSIL run.