### PR TITLE
Method signatures cache improvements

### DIFF
--- a/JSIL.Libraries/Sources/JSIL.Core.js
+++ b/JSIL.Libraries/Sources/JSIL.Core.js
@@ -571,6 +571,26 @@ JSIL.Memoize = function Memoize (value) {
   };
 };
 
+JSIL.MemoizeTypes = function MemoizeTypes(storage, valueProvider, args) {
+  var argTypes = "";
+  for (var i = 0, l = args.length; i < l; i++) {
+    var type = args[i].__TypeId__;
+    if (typeof (type) === "undefined") {
+      throw new Error("Type with __TypeId__ expected");
+    }
+    argTypes += (type + ":");
+  }
+  var cache = storage.cache;
+  if (typeof (cache) === "undefined") {
+    storage.cache = {};
+  }
+  var result = storage.cache[argTypes];
+  if (typeof (result) === "undefined") {
+    result = valueProvider();
+    storage.cache[argTypes] = result;
+  }
+  return result;
+};
 
 JSIL.PreInitMembrane = function (target, initializer) {
   if (typeof (initializer) !== "function")

--- a/JSIL/AssemblyTranslator.cs
+++ b/JSIL/AssemblyTranslator.cs
@@ -1230,8 +1230,8 @@ namespace JSIL {
             var signatureCacher = new SignatureCacher(
                 TypeInfoProvider,
                 !Configuration.CodeGenerator.DisableGenericSignaturesLocalCache.GetValueOrDefault(false),
-                Configuration.CodeGenerator.PreferLocalCacheForGenericMethodSignatures.GetValueOrDefault(false),
-                Configuration.CodeGenerator.PreferLocalCacheForGenericInterfaceMethodSignatures.GetValueOrDefault(false),
+                Configuration.CodeGenerator.PreferLocalCacheForGenericMethodSignatures.GetValueOrDefault(true),
+                Configuration.CodeGenerator.PreferLocalCacheForGenericInterfaceMethodSignatures.GetValueOrDefault(true),
                 Configuration.CodeGenerator.CacheOneMethodSignaturePerMethod.GetValueOrDefault(true));
             var baseMethodCacher = new BaseMethodCacher(TypeInfoProvider, typedef);
 

--- a/JSIL/AssemblyTranslator.cs
+++ b/JSIL/AssemblyTranslator.cs
@@ -1227,7 +1227,12 @@ namespace JSIL {
             ref int nextDisambiguatedId
         ) {
             var typeCacher = new TypeExpressionCacher(typedef);
-            var signatureCacher = new SignatureCacher(TypeInfoProvider, Configuration.CodeGenerator.CacheGenericMethodSignatures.GetValueOrDefault(true));
+            var signatureCacher = new SignatureCacher(
+                TypeInfoProvider,
+                !Configuration.CodeGenerator.DisableGenericSignaturesLocalCache.GetValueOrDefault(false),
+                Configuration.CodeGenerator.PreferLocalCacheForGenericMethodSignatures.GetValueOrDefault(false),
+                Configuration.CodeGenerator.PreferLocalCacheForGenericInterfaceMethodSignatures.GetValueOrDefault(false),
+                Configuration.CodeGenerator.CacheOneMethodSignaturePerMethod.GetValueOrDefault(true));
             var baseMethodCacher = new BaseMethodCacher(TypeInfoProvider, typedef);
 
             TypeInfoProvider.GetTypeInformation(typedef);

--- a/JSIL/Configuration.cs
+++ b/JSIL/Configuration.cs
@@ -35,7 +35,10 @@ namespace JSIL.Translator {
             public bool? EliminateTemporaries;
             public bool? EliminateRedundantControlFlow;
             public bool? CacheMethodSignatures;
-            public bool? CacheGenericMethodSignatures;
+            public bool? DisableGenericSignaturesLocalCache;
+            public bool? PreferLocalCacheForGenericMethodSignatures;
+            public bool? PreferLocalCacheForGenericInterfaceMethodSignatures;
+            public bool? CacheOneMethodSignaturePerMethod;
             public bool? CacheTypeExpressions;
             public bool? CacheBaseMethodHandles;
             public bool? EliminatePointlessFinallyBlocks;
@@ -68,8 +71,14 @@ namespace JSIL.Translator {
                     result.EliminateRedundantControlFlow = EliminateRedundantControlFlow;
                 if (CacheMethodSignatures.HasValue)
                     result.CacheMethodSignatures = CacheMethodSignatures;
-                if (CacheGenericMethodSignatures.HasValue)
-                    result.CacheGenericMethodSignatures = CacheGenericMethodSignatures;
+                if (DisableGenericSignaturesLocalCache.HasValue)
+                    result.DisableGenericSignaturesLocalCache = DisableGenericSignaturesLocalCache;
+                if (PreferLocalCacheForGenericMethodSignatures.HasValue)
+                    result.PreferLocalCacheForGenericMethodSignatures = PreferLocalCacheForGenericMethodSignatures;
+                if (PreferLocalCacheForGenericInterfaceMethodSignatures.HasValue)
+                    result.PreferLocalCacheForGenericInterfaceMethodSignatures = PreferLocalCacheForGenericInterfaceMethodSignatures;
+                if (CacheOneMethodSignaturePerMethod.HasValue)
+                    result.CacheOneMethodSignaturePerMethod = CacheOneMethodSignaturePerMethod;
                 if (CacheTypeExpressions.HasValue)
                     result.CacheTypeExpressions = CacheTypeExpressions;
                 if (CacheBaseMethodHandles.HasValue)

--- a/JSIL/JavascriptAssemblyEmitter.cs
+++ b/JSIL/JavascriptAssemblyEmitter.cs
@@ -1237,14 +1237,46 @@ namespace JSIL {
             var css = signatureCacher.Global.Signatures.OrderBy((cs) => cs.Value).ToArray();
             if (css.Length > 0) {
                 foreach (var cs in css) {
-                    Formatter.WriteRaw("var $S{0:X2} = function () ", cs.Value);
-                    Formatter.OpenBrace();
-                    Formatter.WriteRaw("return ($S{0:X2} = JSIL.Memoize(", cs.Value);
-                    Formatter.Signature(cs.Key.Method, cs.Key.Signature, astEmitter.ReferenceContext, cs.Key.IsConstructor, false);
-                    Formatter.WriteRaw(")) ()");
-                    Formatter.Semicolon(true);
-                    Formatter.CloseBrace(false);
-                    Formatter.Semicolon(true);
+                    if (cs.Key.RewritenGenericParametersCount == 0)
+                    {
+                        Formatter.WriteRaw("var $S{0:X2} = function () ", cs.Value);
+                        Formatter.OpenBrace();
+                        Formatter.WriteRaw("return ($S{0:X2} = JSIL.Memoize(", cs.Value);
+                        Formatter.Signature(cs.Key.Method, cs.Key.Signature, astEmitter.ReferenceContext,
+                            cs.Key.IsConstructor, false, true);
+                        Formatter.WriteRaw(")) ()");
+                        Formatter.Semicolon(true);
+                        Formatter.CloseBrace(false);
+                        Formatter.Semicolon(true);
+                    }
+                    else
+                    {
+                        Formatter.WriteRaw("var $S{0:X2} = function ", cs.Value);
+                        Formatter.LPar();
+                        Formatter.CommaSeparatedList(
+                            Enumerable.Range(1, cs.Key.RewritenGenericParametersCount).Select(item => "arg" + item),
+                            astEmitter.ReferenceContext,
+                            ListValueType.Raw);
+                        Formatter.RPar();
+                        Formatter.Space();
+
+                        Formatter.OpenBrace();
+                        Formatter.WriteRaw("return JSIL.MemoizeTypes($S{0:X2}, function() {{return ", cs.Value);
+                        Formatter.Signature(cs.Key.Method, cs.Key.Signature, astEmitter.ReferenceContext,
+                            cs.Key.IsConstructor, false, true);
+                        Formatter.WriteRaw(";}");
+                        Formatter.Comma();
+                        Formatter.OpenBracket();
+                        Formatter.CommaSeparatedList(
+                            Enumerable.Range(1, cs.Key.RewritenGenericParametersCount).Select(item => "arg" + item),
+                            astEmitter.ReferenceContext,
+                            ListValueType.Raw);
+                        Formatter.CloseBracket();
+                        Formatter.WriteRaw(")");
+                        Formatter.Semicolon(true);
+                        Formatter.CloseBrace(false);
+                        Formatter.Semicolon(true);
+                    }
                 }
             }
 
@@ -1266,16 +1298,48 @@ namespace JSIL {
             var cims = signatureCacher.Global.InterfaceMembers.OrderBy((cim) => cim.Value).ToArray();
             if (cims.Length > 0) {
                 foreach (var cim in cims) {
-                    Formatter.WriteRaw("var $IM{0:X2} = function () ", cim.Value);
-                    Formatter.OpenBrace();
-                    Formatter.WriteRaw("return ($IM{0:X2} = JSIL.Memoize(", cim.Value);
-                    Formatter.Identifier(cim.Key.InterfaceType, astEmitter.ReferenceContext, false);
-                    Formatter.Dot();
-                    Formatter.Identifier(cim.Key.InterfaceMember, EscapingMode.MemberIdentifier);
-                    Formatter.WriteRaw(")) ()");
-                    Formatter.Semicolon(true);
-                    Formatter.CloseBrace(false);
-                    Formatter.Semicolon(true);
+                    if (cim.Key.RewritenGenericParametersCount == 0)
+                    {
+                        Formatter.WriteRaw("var $IM{0:X2} = function () ", cim.Value);
+                        Formatter.OpenBrace();
+                        Formatter.WriteRaw("return ($IM{0:X2} = JSIL.Memoize(", cim.Value);
+                        Formatter.Identifier(cim.Key.InterfaceType, astEmitter.ReferenceContext, false);
+                        Formatter.Dot();
+                        Formatter.Identifier(cim.Key.InterfaceMember, EscapingMode.MemberIdentifier);
+                        Formatter.WriteRaw(")) ()");
+                        Formatter.Semicolon(true);
+                        Formatter.CloseBrace(false);
+                        Formatter.Semicolon(true);
+                    }
+                    else
+                    {
+                        Formatter.WriteRaw("var $IM{0:X2} = function ", cim.Value);
+                        Formatter.LPar();
+                        Formatter.CommaSeparatedList(
+                            Enumerable.Range(1, cim.Key.RewritenGenericParametersCount).Select(item => "arg" + item),
+                            astEmitter.ReferenceContext,
+                            ListValueType.Raw);
+                        Formatter.RPar();
+                        Formatter.Space();
+
+                        Formatter.OpenBrace();
+                        Formatter.WriteRaw("return JSIL.MemoizeTypes($IM{0:X2}, function() {{return ", cim.Value);
+                        Formatter.Identifier(cim.Key.InterfaceType, astEmitter.ReferenceContext, false);
+                        Formatter.Dot();
+                        Formatter.Identifier(cim.Key.InterfaceMember, EscapingMode.MemberIdentifier);
+                        Formatter.WriteRaw(";}");
+                        Formatter.Comma();
+                        Formatter.OpenBracket();
+                        Formatter.CommaSeparatedList(
+                            Enumerable.Range(1, cim.Key.RewritenGenericParametersCount).Select(item => "arg" + item),
+                            astEmitter.ReferenceContext,
+                            ListValueType.Raw);
+                        Formatter.CloseBracket();
+                        Formatter.WriteRaw(")");
+                        Formatter.Semicolon(true);
+                        Formatter.CloseBrace(false);
+                        Formatter.Semicolon(true);
+                    }
                 }
             }
 

--- a/JSIL/MethodSignature.cs
+++ b/JSIL/MethodSignature.cs
@@ -116,16 +116,14 @@ namespace JSIL.Internal {
             var gpOwner = genericParameter.Owner as TypeReference;
             var git = typeDeclaringMethod as GenericInstanceType;
 
-            if (git != null) {
+            if (git != null && gpOwner != null) {
                 for (var i = 0; i < git.ElementType.GenericParameters.Count; i++) {
                     var _ = git.ElementType.GenericParameters[i];
                     var owner = _.Owner as TypeReference;
 
-                    if (gpOwner != null) {
-                        // Reject generic parameters with different owners than the type declaring the method.
-                        if (!TypeUtil.TypesAreEqual(gpOwner, owner, false))
-                            continue;
-                    }
+                    // Reject generic parameters with different owners than the type declaring the method.
+                    if (!TypeUtil.TypesAreEqual(gpOwner, owner, false))
+                        continue;
 
                     if ((_.Name == genericParameter.Name) || (_.Position == genericParameter.Position))
                         return git.GenericArguments[i];

--- a/JSIL/Transforms/CacheSignatures.cs
+++ b/JSIL/Transforms/CacheSignatures.cs
@@ -8,29 +8,166 @@ using Mono.Cecil;
 
 namespace JSIL.Transforms {
     public class SignatureCacher : JSAstVisitor {
+        private const string GenericParameterHostNamespace = "$JSIL";
+        private const string GenericParameterHostName = "ParameterHost";
+
+        private const string GenericParameterHostFullName =
+            GenericParameterHostNamespace + "." + GenericParameterHostName;
+
+        public static class GenericTypesRewriter {
+            private static readonly TypeReference GerericArgumentHost =
+                new TypeReference(GenericParameterHostNamespace,
+                    GenericParameterHostName, null,
+                    new AssemblyNameReference(GenericParameterHostName, new Version()));
+
+            public static RewritedCacheRecord<MethodSignature> Normalized (MethodReference method,
+                MethodSignature signature, bool isConstructor) {
+                var targetMappings = new Dictionary<GenericParameter, int>(new GenericParameterComparer());
+                var resultSignature = new MethodSignature(signature.TypeInfo,
+                    isConstructor
+                        ? ResolveTypeReference(method, method.DeclaringType, targetMappings)
+                        : ResolveTypeReference(method, signature.ReturnType, targetMappings),
+                    signature.ParameterTypes.Select(item => ResolveTypeReference(method, item, targetMappings))
+                        .ToArray(),
+                    signature.GenericParameterNames);
+
+                var mappings = targetMappings.OrderBy(item => item.Value).Select(item => item.Key).ToArray();
+
+                return new RewritedCacheRecord<MethodSignature>(
+                    resultSignature,
+                    mappings);
+            }
+
+            public static MethodSignature NormalizedConstructorSignature (MethodReference method,
+                MethodSignature signature, bool isConstructor) {
+                return new MethodSignature(signature.TypeInfo,
+                    isConstructor ? method.DeclaringType : signature.ReturnType,
+                    signature.ParameterTypes,
+                    signature.GenericParameterNames);
+            }
+
+            public static RewritedCacheRecord<TypeReference> Normalized (TypeReference declaringType) {
+                var targetMappings = new Dictionary<GenericParameter, int>(new GenericParameterComparer());
+                var resolvedType = GenericTypesRewriter.ResolveTypeReference(
+                    declaringType,
+                    tr => {
+                        if (tr is GenericParameter) {
+                            var gp = (GenericParameter) tr;
+                            return GenericTypesRewriter.ReplaceWithGenericArgument(gp, targetMappings);
+                        }
+                        return tr;
+                    });
+
+                var mappings = targetMappings.OrderBy(item => item.Value).Select(item => item.Key).ToArray();
+
+                return new RewritedCacheRecord<TypeReference>(resolvedType, mappings);
+            }
+
+            private static TypeReference ResolveTypeReference (MethodReference method, TypeReference typeReference,
+                Dictionary<GenericParameter, int> mappings) {
+                var resolvedMethod = method.Resolve();
+
+                return GenericTypesRewriter.ResolveTypeReference(
+                    typeReference,
+                    tr => {
+                        if (tr is GenericParameter) {
+                            var gp = (GenericParameter) tr;
+                            var result = MethodSignature.ResolveGenericParameter(gp, method.DeclaringType);
+
+                            if (result is GenericParameter) {
+                                gp = (GenericParameter) result;
+                                result = null;
+                            }
+                            if (result == null) {
+                                if (gp.Owner is MethodReference) {
+                                    var mr = (MethodReference) gp.Owner;
+                                    if (mr.Resolve() == resolvedMethod)
+                                        return gp;
+                                }
+
+                                return GenericTypesRewriter.ReplaceWithGenericArgument(gp, mappings);
+                            }
+
+                            return result;
+                        }
+                        return tr;
+                    });
+            }
+
+            private static TypeReference ResolveTypeReference (TypeReference typeReference,
+                Func<TypeReference, TypeReference> resolver) {
+                typeReference = resolver(typeReference);
+                if (typeReference is GenericInstanceType) {
+                    var git = (GenericInstanceType) typeReference;
+                    var newType = new GenericInstanceType(ResolveTypeReference(git.ElementType, resolver));
+
+                    foreach (var ga in git.GenericArguments) {
+                        newType.GenericArguments.Add(ResolveTypeReference(ga, resolver));
+                    }
+                    return newType;
+                }
+                if (typeReference is ArrayType) {
+                    var at = (ArrayType) typeReference;
+                    var newType = new ArrayType(ResolveTypeReference(at.ElementType, resolver), at.Rank);
+                    return newType;
+                }
+                if (typeReference is ByReferenceType) {
+                    var brt = (ByReferenceType) typeReference;
+                    var newType = new ByReferenceType(ResolveTypeReference(brt.ElementType, resolver));
+                    return newType;
+                }
+
+                return typeReference;
+            }
+
+            private static GenericParameter ReplaceWithGenericArgument (GenericParameter input,
+                Dictionary<GenericParameter, int> mappings) {
+                int index;
+                if (!mappings.TryGetValue(input, out index)) {
+                    index = mappings.Count;
+                    mappings.Add(input, index);
+                }
+                return new GenericParameter("arg" + (index + 1), GerericArgumentHost);
+            }
+        }
+
+        public struct RewritedCacheRecord<T> {
+            public readonly GenericParameter[] RewritedGenericParameters;
+            public readonly T CacheRecord;
+
+            public RewritedCacheRecord (T cacheRecord, GenericParameter[] rewritedGenericParameters) {
+                RewritedGenericParameters = rewritedGenericParameters;
+                CacheRecord = cacheRecord;
+            }
+        }
+
         public struct CachedSignatureRecord {
             public readonly MethodReference Method;
             public readonly MethodSignature Signature;
             public readonly bool IsConstructor;
+            public readonly int RewritenGenericParametersCount;
 
-            public CachedSignatureRecord (MethodReference method, MethodSignature signature, bool isConstructor) {
+            public CachedSignatureRecord (MethodReference method, MethodSignature signature, bool isConstructor,
+                int rewritenGenericParametersCount = 0) {
                 Method = method;
                 Signature = signature;
                 IsConstructor = isConstructor;
+
+                RewritenGenericParametersCount = rewritenGenericParametersCount;
             }
 
             public override int GetHashCode () {
-                return Method.Name.GetHashCode() ^ Signature.GetHashCode() ^ IsConstructor.GetHashCode();
+                return (Method != null ? Method.Name.GetHashCode() : 0) ^ Signature.GetHashCode() ^ IsConstructor.GetHashCode() ^ RewritenGenericParametersCount;
             }
 
             public bool Equals (ref CachedSignatureRecord rhs) {
+                var areMethodEquals = (Method == rhs.Method) ||
+                    (Method != null && rhs.Method != null && Method.FullName == rhs.Method.FullName);
+
                 var result =
-                    (
-                        (Method == rhs.Method) ||
-                        (Method.FullName == rhs.Method.FullName)
-                    ) &&
-                    Signature.Equals(rhs.Signature) &&
-                    (IsConstructor == rhs.IsConstructor);
+                    areMethodEquals &&
+                        Signature.Equals(rhs.Signature) &&
+                        (IsConstructor == rhs.IsConstructor);
 
                 if (!result)
                     return false;
@@ -40,7 +177,7 @@ namespace JSIL.Transforms {
 
             public override bool Equals (object obj) {
                 if (obj is CachedSignatureRecord) {
-                    var rhs = (CachedSignatureRecord)obj;
+                    var rhs = (CachedSignatureRecord) obj;
                     return Equals(ref rhs);
                 } else
                     return base.Equals(obj);
@@ -57,19 +194,41 @@ namespace JSIL.Transforms {
             }
         }
 
+        public class IgnoreMethodCachedSignatureRecordComparer : IEqualityComparer<CachedSignatureRecord> {
+            public int GetHashCode (CachedSignatureRecord record) {
+                return record.Signature.GetHashCode() ^ record.IsConstructor.GetHashCode() ^
+                    record.RewritenGenericParametersCount;
+            }
+
+            public bool Equals (CachedSignatureRecord lhs, CachedSignatureRecord rhs) {
+                var result =
+                    lhs.Signature.Equals(rhs.Signature) &&
+                        (lhs.IsConstructor == rhs.IsConstructor);
+
+                if (!result)
+                    return false;
+                else
+                    return result;
+            }
+        }
+
         public struct CachedInterfaceMemberRecord {
             public readonly TypeReference InterfaceType;
             public readonly string InterfaceMember;
+            public readonly int RewritenGenericParametersCount;
 
-            public CachedInterfaceMemberRecord (TypeReference declaringType, string memberName) {
+            public CachedInterfaceMemberRecord (TypeReference declaringType, string memberName,
+                int rewritenGenericParametersCount = 0) {
                 InterfaceType = declaringType;
                 InterfaceMember = memberName;
+                RewritenGenericParametersCount = rewritenGenericParametersCount;
             }
+
 
             public bool Equals (ref CachedInterfaceMemberRecord rhs) {
                 var result =
                     TypeUtil.TypesAreEqual(InterfaceType, rhs.InterfaceType, true) &&
-                    InterfaceMember.Equals(rhs.InterfaceMember);
+                        InterfaceMember.Equals(rhs.InterfaceMember);
 
                 if (!result)
                     return false;
@@ -79,14 +238,14 @@ namespace JSIL.Transforms {
 
             public override bool Equals (object obj) {
                 if (obj is CachedInterfaceMemberRecord) {
-                    var rhs = (CachedInterfaceMemberRecord)obj;
+                    var rhs = (CachedInterfaceMemberRecord) obj;
                     return Equals(ref rhs);
                 } else
                     return base.Equals(obj);
             }
 
             public override int GetHashCode () {
-                return InterfaceType.Name.GetHashCode() ^ InterfaceMember.GetHashCode();
+                return InterfaceType.Name.GetHashCode() ^ InterfaceMember.GetHashCode() ^ RewritenGenericParametersCount;
             }
         }
 
@@ -101,29 +260,47 @@ namespace JSIL.Transforms {
         }
 
         public class CacheSet {
+            private static readonly IgnoreMethodCachedSignatureRecordComparer IgnoreMethodComparer =
+                new IgnoreMethodCachedSignatureRecordComparer();
+
             private static readonly CachedSignatureRecordComparer Comparer = new CachedSignatureRecordComparer();
-            private static readonly CachedInterfaceMemberRecordComparer InterfaceMemberComparer = new CachedInterfaceMemberRecordComparer();
+
+            private static readonly CachedInterfaceMemberRecordComparer InterfaceMemberComparer =
+                new CachedInterfaceMemberRecordComparer();
 
             public readonly Dictionary<CachedSignatureRecord, int> Signatures;
             public readonly Dictionary<CachedInterfaceMemberRecord, int> InterfaceMembers;
 
-            public CacheSet () {
-                Signatures = new Dictionary<CachedSignatureRecord, int>(Comparer);
+            public CacheSet (bool useMethodSignaturePerMethod) {
+                Signatures =
+                    new Dictionary<CachedSignatureRecord, int>(useMethodSignaturePerMethod
+                        ? (IEqualityComparer<CachedSignatureRecord>) Comparer
+                        : IgnoreMethodComparer);
                 InterfaceMembers = new Dictionary<CachedInterfaceMemberRecord, int>(InterfaceMemberComparer);
             }
         }
 
         public readonly bool LocalCachingEnabled;
+        public readonly bool PreferLocalCacheForGenericMethodSignatures;
+        public readonly bool PreferLocalCacheForGenericInterfaceMethodSignatures;
+        public readonly bool UseMethodSignaturePerMethod;
+
         public readonly Dictionary<MemberIdentifier, CacheSet> LocalCachedSets;
-        public readonly CacheSet Global = new CacheSet();
+        public readonly CacheSet Global;
         private readonly Stack<JSFunctionExpression> FunctionStack = new Stack<JSFunctionExpression>();
 
-        public SignatureCacher (TypeInfoProvider typeInfo, bool localCachingEnabled) {
+        public SignatureCacher (TypeInfoProvider typeInfo, bool localCachingEnabled,
+            bool preferLocalCacheForGenericMethodSignatures, bool preferLocalCacheForGenericInterfaceMethodSignatures,
+            bool useMethodSignaturePerMethod) {
+            Global = new CacheSet(useMethodSignaturePerMethod);
             LocalCachedSets = new Dictionary<MemberIdentifier, CacheSet>(
                 new MemberIdentifier.Comparer(typeInfo)
-            );
+                );
             VisitNestedFunctions = true;
             LocalCachingEnabled = localCachingEnabled;
+            PreferLocalCacheForGenericMethodSignatures = preferLocalCacheForGenericMethodSignatures;
+            PreferLocalCacheForGenericInterfaceMethodSignatures = preferLocalCacheForGenericInterfaceMethodSignatures;
+            UseMethodSignaturePerMethod = useMethodSignaturePerMethod;
         }
 
         private CacheSet GetCacheSet (bool cacheLocally) {
@@ -136,47 +313,62 @@ namespace JSIL.Transforms {
 
                 var functionIdentifier = fn.Method.Method.Identifier;
                 if (!LocalCachedSets.TryGetValue(functionIdentifier, out result))
-                    result = LocalCachedSets[functionIdentifier] = new CacheSet();
+                    result = LocalCachedSets[functionIdentifier] = new CacheSet(UseMethodSignaturePerMethod);
             }
 
             return result;
         }
 
         private void CacheSignature (MethodReference method, MethodSignature signature, bool isConstructor) {
-            Func<GenericParameter, bool> filter =
-                (gp) => {
-                    // If the generic parameter can be expanded given the type that declared the method, don't cache locally.
-                    var resolved = MethodSignature.ResolveGenericParameter(gp, method.DeclaringType);
-                    // Note that we have to ensure the resolved type is not generic either. A generic parameter can resolve to a
-                    //  *different* generic parameter, and that is still correct - i.e. SomeMethod<A> calls SomeMethod<B>,
-                    //  in that case resolving B will yield A.
-                    if ((resolved != gp) && (resolved != null) && !TypeUtil.IsOpenType(resolved))
-                        return false;
+            bool cacheLocally;
+            CachedSignatureRecord record;
+            if (LocalCachingEnabled && PreferLocalCacheForGenericMethodSignatures) {
+                record = new CachedSignatureRecord(method,
+                    GenericTypesRewriter.NormalizedConstructorSignature(method, signature, isConstructor), isConstructor);
+                signature = record.Signature;
 
-                    var ownerMethod = gp.Owner as MethodReference;
-                    if (ownerMethod == null)
-                        return true;
+                Func<GenericParameter, bool> filter =
+                    (gp) => {
+                        // If the generic parameter can be expanded given the type that declared the method, don't cache locally.
+                        var resolved = MethodSignature.ResolveGenericParameter(gp, method.DeclaringType);
+                        // Note that we have to ensure the resolved type is not generic either. A generic parameter can resolve to a
+                        //  *different* generic parameter, and that is still correct - i.e. SomeMethod<A> calls SomeMethod<B>,
+                        //  in that case resolving B will yield A.
+                        if ((resolved != gp) && (resolved != null) && !TypeUtil.IsOpenType(resolved))
+                            return false;
 
-                    if (ownerMethod == method)
-                        return false;
-                    // FIXME: Nulls?
-                    else if (ownerMethod.Resolve() == method.Resolve())
-                        return false;
-                    else
-                        return true;
-                };
+                        var ownerMethod = gp.Owner as MethodReference;
+                        if (ownerMethod == null)
+                            return true;
 
-            var cacheLocally = false;
+                        if (ownerMethod == method)
+                            return false;
+                        // FIXME: Nulls?
+                        else if (ownerMethod.Resolve() == method.Resolve())
+                            return false;
+                        else
+                            return true;
+                    };
 
-            if (TypeUtil.IsOpenType(signature.ReturnType, filter))
-                cacheLocally = true;
-            else if (signature.ParameterTypes.Any((gp) => TypeUtil.IsOpenType(gp, filter)))
-                cacheLocally = true;
-            else if (TypeUtil.IsOpenType(method.DeclaringType, filter))
-                cacheLocally = true;
+                cacheLocally = false;
+
+                if (TypeUtil.IsOpenType(signature.ReturnType, filter))
+                    cacheLocally = true;
+                else if (signature.ParameterTypes.Any((gp) => TypeUtil.IsOpenType(gp, filter)))
+                    cacheLocally = true;
+                else if (isConstructor && TypeUtil.IsOpenType(method.DeclaringType, filter))
+                    cacheLocally = true;
+            } else {
+                cacheLocally = false;
+                var rewritenInfo = GenericTypesRewriter.Normalized(method, signature, isConstructor);
+                record = new CachedSignatureRecord(
+                    method,
+                    rewritenInfo.CacheRecord,
+                    isConstructor,
+                    rewritenInfo.RewritedGenericParameters.Length);
+            }
 
             var set = GetCacheSet(cacheLocally);
-            var record = new CachedSignatureRecord(method, signature, isConstructor);
 
             if (!set.Signatures.ContainsKey(record))
                 set.Signatures.Add(record, set.Signatures.Count);
@@ -184,16 +376,25 @@ namespace JSIL.Transforms {
 
         private void CacheInterfaceMember (TypeReference declaringType, string memberName) {
             var cacheLocally = false;
-
-            if (TypeUtil.IsOpenType(declaringType))
-                cacheLocally = true;
+            var originalType = declaringType;
 
             var unexpandedType = declaringType;
             if (!TypeUtil.ExpandPositionalGenericParameters(unexpandedType, out declaringType))
                 declaringType = unexpandedType;
 
+            CachedInterfaceMemberRecord record;
+
+            if (LocalCachingEnabled && PreferLocalCacheForGenericInterfaceMethodSignatures) {
+                if (TypeUtil.IsOpenType(declaringType))
+                    cacheLocally = true;
+                record = new CachedInterfaceMemberRecord(declaringType, memberName);
+            } else {
+                var rewritten = GenericTypesRewriter.Normalized(declaringType);
+                record = new CachedInterfaceMemberRecord(rewritten.CacheRecord, memberName,
+                    rewritten.RewritedGenericParameters.Length);
+            }
+
             var set = GetCacheSet(cacheLocally);
-            var record = new CachedInterfaceMemberRecord(declaringType, memberName);
 
             if (!set.InterfaceMembers.ContainsKey(record))
                 set.InterfaceMembers.Add(record, set.InterfaceMembers.Count);
@@ -204,12 +405,12 @@ namespace JSIL.Transforms {
                 return new JSRawOutputIdentifier(
                     type,
                     "$s{0:X2}", index
-                );
+                    );
             else
                 return new JSRawOutputIdentifier(
                     type,
                     "$im{0:X2}", index
-                );
+                    );
         }
 
         public void VisitNode (JSFunctionExpression fe) {
@@ -253,13 +454,11 @@ namespace JSIL.Transforms {
             }
         }
 
-        public void VisitNode(JSMethodOfExpression methodOf)
-        {
+        public void VisitNode (JSMethodOfExpression methodOf) {
             CacheSignature(methodOf.Reference, methodOf.Method.Signature, false);
         }
 
-        public void VisitNode(JSMethodPointerInfoExpression methodOf)
-        {
+        public void VisitNode (JSMethodPointerInfoExpression methodOf) {
             CacheSignature(methodOf.Reference, methodOf.Method.Signature, false);
         }
 
@@ -315,19 +514,31 @@ namespace JSIL.Transforms {
         /// </summary>
         public void WriteSignatureToOutput (
             JavascriptFormatter output, JSFunctionExpression enclosingFunction,
-            MethodReference methodReference, MethodSignature methodSignature, 
-            TypeReferenceContext referenceContext, 
+            MethodReference methodReference, MethodSignature methodSignature,
+            TypeReferenceContext referenceContext,
             bool forConstructor
-        ) {
+            ) {
             int index;
-            var record = new CachedSignatureRecord(methodReference, methodSignature, forConstructor);
+            CachedSignatureRecord cacheRecord;
+            GenericParameter[] rewrittenGenericParameters = null;
+            if (LocalCachingEnabled && PreferLocalCacheForGenericMethodSignatures) {
+                cacheRecord = new CachedSignatureRecord(methodReference,
+                    GenericTypesRewriter.NormalizedConstructorSignature(methodReference, methodSignature, forConstructor),
+                    forConstructor);
+            } else {
+                RewritedCacheRecord<MethodSignature> rewritten = GenericTypesRewriter.Normalized(methodReference,
+                    methodSignature, forConstructor);
+                cacheRecord = new CachedSignatureRecord(methodReference, rewritten.CacheRecord, forConstructor,
+                    rewritten.RewritedGenericParameters.Length);
+                rewrittenGenericParameters = rewritten.RewritedGenericParameters;
+            }
 
             if ((enclosingFunction.Method != null) && (enclosingFunction.Method.Method != null)) {
                 var functionIdentifier = enclosingFunction.Method.Method.Identifier;
                 CacheSet localSignatureSet;
 
                 if (LocalCachedSets.TryGetValue(functionIdentifier, out localSignatureSet)) {
-                    if (localSignatureSet.Signatures.TryGetValue(record, out index)) {
+                    if (localSignatureSet.Signatures.TryGetValue(cacheRecord, out index)) {
                         output.WriteRaw("$s{0:X2}", index);
 
                         return;
@@ -335,24 +546,41 @@ namespace JSIL.Transforms {
                 }
             }
 
-            if (!Global.Signatures.TryGetValue(record, out index))
+            if (!Global.Signatures.TryGetValue(cacheRecord, out index))
                 output.Signature(methodReference, methodSignature, referenceContext, forConstructor, true);
-            else
-                output.WriteRaw("$S{0:X2}()", index);
+            else {
+                output.WriteRaw("$S{0:X2}", index);
+                output.LPar();
+                if (rewrittenGenericParameters != null) {
+                    output.CommaSeparatedList(rewrittenGenericParameters, referenceContext);
+                }
+                output.RPar();
+            }
         }
 
         /// <summary>
         /// Writes an interface member reference to the output.
         /// </summary>
         public void WriteInterfaceMemberToOutput (
-            JavascriptFormatter output, Compiler.Extensibility.IAstEmitter astEmitter, JSFunctionExpression enclosingFunction,
+            JavascriptFormatter output, Compiler.Extensibility.IAstEmitter astEmitter,
+            JSFunctionExpression enclosingFunction,
             JSMethod jsMethod, JSExpression method,
             TypeReferenceContext referenceContext
-        ) {
+            ) {
             int index;
-            var record = new CachedInterfaceMemberRecord(jsMethod.Reference.DeclaringType, jsMethod.Identifier);
 
-            if ((enclosingFunction.Method != null) || (enclosingFunction.Method.Method != null)) {
+            CachedInterfaceMemberRecord record;
+            GenericParameter[] rewrittenGenericParameters = null;
+            if (LocalCachingEnabled && PreferLocalCacheForGenericInterfaceMethodSignatures) {
+                record = new CachedInterfaceMemberRecord(jsMethod.Reference.DeclaringType, jsMethod.Identifier);
+            } else {
+                var rewritten = GenericTypesRewriter.Normalized(jsMethod.Reference.DeclaringType);
+                record = new CachedInterfaceMemberRecord(rewritten.CacheRecord, jsMethod.Identifier,
+                    rewritten.RewritedGenericParameters.Length);
+                rewrittenGenericParameters = rewritten.RewritedGenericParameters;
+            }
+
+            if (enclosingFunction.Method != null && enclosingFunction.Method.Method != null) {
                 var functionIdentifier = enclosingFunction.Method.Method.Identifier;
                 CacheSet localSignatureSet;
 
@@ -369,8 +597,38 @@ namespace JSIL.Transforms {
                 output.Identifier(jsMethod.Reference.DeclaringType, referenceContext, false);
                 output.Dot();
                 astEmitter.Emit(method);
-            } else
-                output.WriteRaw("$IM{0:X2}()", index);
+            } else {
+                output.WriteRaw("$IM{0:X2}", index);
+                output.LPar();
+                if (rewrittenGenericParameters != null) {
+                    output.CommaSeparatedList(rewrittenGenericParameters, referenceContext);
+                }
+                output.RPar();
+            }
+        }
+
+        public static bool IsTypeArgument (TypeReference typeReference) {
+            if (typeReference is GenericParameter) {
+                var gp = (GenericParameter) typeReference;
+                if (gp.Owner is TypeReference) {
+                    var owner = (TypeReference) gp.Owner;
+                    if (owner.Scope.Name == GenericParameterHostName && owner.FullName == GenericParameterHostFullName) {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+    }
+
+    public class GenericParameterComparer : IEqualityComparer<GenericParameter> {
+        public bool Equals (GenericParameter x, GenericParameter y) {
+            return TypeUtil.TypesAreEqual(x, y);
+        }
+
+        public int GetHashCode (GenericParameter obj) {
+            return obj.FullName.GetHashCode();
         }
     }
 }

--- a/JSIL/TypeUtil.cs
+++ b/JSIL/TypeUtil.cs
@@ -10,6 +10,8 @@ using Mono.Cecil;
 using TypeDefinition = Mono.Cecil.TypeDefinition;
 
 namespace JSIL {
+    using JSIL.Transforms;
+
     public static class TypeUtil {
         public static TypeReference GetElementType (TypeReference type, bool throwOnFail) {
             type = StripModifiers(type);
@@ -566,7 +568,7 @@ namespace JSIL {
 
         private static string GetActualScope (TypeReference tr) {
             var result = tr.Scope.Name;
-            if (tr.GetType() == typeof (TypeReference))
+            if (tr.GetType() == typeof (TypeReference) && tr.Module != null)
             {
                 var definition = tr.Resolve();
                 if (definition != null)
@@ -641,6 +643,14 @@ namespace JSIL {
             if ((targetGp != null) || (sourceGp != null)) {
                 if ((targetGp == null) || (sourceGp == null))
                     return false;
+
+                var isTargetGpArg = SignatureCacher.IsTypeArgument(targetGp);
+                var isSourceGpArg = SignatureCacher.IsTypeArgument(targetGp);
+
+                if (isSourceGpArg || isTargetGpArg)
+                {
+                    return isSourceGpArg && isTargetGpArg && targetGp.Name == sourceGp.Name;
+                }
 
                 TypeReference temp;
 


### PR DESCRIPTION
Here i implemented caching of open generic signatures (#970) and preserving only one signature cache per signature (896).

Both features are hidden under default settings.
(1) To enable global caching for open generic signatures user should change config:
CodeGenerator.PreferLocalCacheForGenericMethodSignatures=false
(2) To enable global caching for open generic interface method signatures user should change config:
CodeGenerator.PreferLocalCacheForGenericInterfaceMethodSignatures=false
(3) To enable storing only one method signature cache per signature:
CodeGenerator.CacheOneMethodSignaturePerMethod=false

I will still work more on method calls performance improvements, as all suggested option could either increase or decrease execution time dependent on usage scenario.

For my project I get about 20% performance improvement with `CodeGenerator.PreferLocalCacheForGenericMethodSignatures=false`. All other settings are actually have not changed measured performance of my application.