### PR TITLE
Fixed clean build/rebuild under VS, packages updated

### DIFF
--- a/JSIL.Libraries/.bin/git.cmd
+++ b/JSIL.Libraries/.bin/git.cmd
@@ -1,3 +1,3 @@
 @echo off
 SET PATH=%~dp0;%PATH%
-"%~dp0node" "%~dp0..\..\packages\NoGit.0.0.8\node_modules\nogit\bin\git.js" %*
+"%~dp0node" "%~dp0..\..\packages\NoGit.0.1.0\node_modules\nogit\bin\git.js" %*

--- a/JSIL.Libraries/.bin/node.cmd
+++ b/JSIL.Libraries/.bin/node.cmd
@@ -1,3 +1,3 @@
 @echo off
 SET PATH=%PATH%;%~dp0
-"%~dp0..\..\packages\Node.js.0.12.7\node.exe" %*
+"%~dp0..\..\packages\Node.js.5.3.0\node.exe" %*

--- a/JSIL.Libraries/.bin/npm.cmd
+++ b/JSIL.Libraries/.bin/npm.cmd
@@ -1,4 +1,4 @@
 @echo off
 SET PATH=%~dp0;%PATH%
 SET npm_config_git=%~dp0git.cmd
-"%~dp0node" "%~dp0..\..\packages\Npm.1.4.15.2\node_modules\npm\bin\npm-cli.js" %*
+"%~dp0node" "%~dp0..\..\packages\Npm.3.5.2\node_modules\npm\bin\npm-cli.js" %*

--- a/JSIL.Libraries/JSIL.Libraries.csproj
+++ b/JSIL.Libraries/JSIL.Libraries.csproj
@@ -47,15 +47,13 @@
     <Content Include="Includes\Bootstrap\Dynamic\Classes\System.Runtime.CompilerServices.CallSite.js" />
     <Content Include="Includes\Bootstrap\Dynamic\Main.js" />
     <Content Include="Includes\Core\Reflection\Classes\System.Reflection.IntrospectionExtensions.js" />
-    <None Include="package.json" />
-    <None Include="packages.config">
-      <SubType>Designer</SubType>
-    </None>
-  </ItemGroup>
-  <ItemGroup>
     <None Include=".bin\git.cmd" />
     <None Include=".bin\node.cmd" />
     <None Include=".bin\npm.cmd" />
+    <None Include="package.json" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
     <Content Include="gulpfile.js" />
     <Content Include="Includes\Bootstrap\Async\Classes\System.Threading.ManualResetEventSlim.js" />
     <Content Include="Includes\Bootstrap\Async\Classes\System.AggregateException.js" />

--- a/JSIL.Libraries/packages.config
+++ b/JSIL.Libraries/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Node.js" version="0.12.7" targetFramework="net4" />
-  <package id="NoGit" version="0.0.8" targetFramework="net4" />
-  <package id="Npm" version="1.4.15.2" targetFramework="net4" />
+  <package id="Node.js" version="5.3.0" targetFramework="net45" />
+  <package id="NoGit" version="0.1.0" targetFramework="net45" />
+  <package id="Npm" version="3.5.2" targetFramework="net45" />
 </packages>

--- a/JSIL.sln
+++ b/JSIL.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.23107.0
+VisualStudioVersion = 14.0.25123.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compiler", "Compiler\Compiler.csproj", "{C7BF4561-20DD-4E49-8B5A-4E8AF032C47A}"
 	ProjectSection(ProjectDependencies) = postProject
@@ -19,6 +19,10 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "JSIL.DeadCodeAnalyzer", "Compiler\Analyzers\DeadCodeAnalyzer\JSIL.DeadCodeAnalyzer.csproj", "{976F07E6-5D98-4A82-ADD0-3ADDB70020C7}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ICSharpCode.Decompiler", "Upstream\ILSpy\ICSharpCode.Decompiler\ICSharpCode.Decompiler.csproj", "{984CC812-9470-4A13-AFF9-CC44068D666C}"
+	ProjectSection(ProjectDependencies) = postProject
+		{3B2A5653-EC97-4001-BB9B-D90F1AF2C371} = {3B2A5653-EC97-4001-BB9B-D90F1AF2C371}
+		{53DCA265-3C3C-42F9-B647-F72BA678122B} = {53DCA265-3C3C-42F9-B647-F72BA678122B}
+	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ICSharpCode.NRefactory", "Upstream\ILSpy\NRefactory\ICSharpCode.NRefactory\ICSharpCode.NRefactory.csproj", "{3B2A5653-EC97-4001-BB9B-D90F1AF2C371}"
 EndProject

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -48,8 +48,8 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="FSharp.Compiler.CodeDom, Version=0.9.3.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
-      <HintPath>..\packages\FSharp.Compiler.CodeDom.0.9.3.0\lib\net40\FSharp.Compiler.CodeDom.dll</HintPath>
+    <Reference Include="FSharp.Compiler.CodeDom, Version=1.0.0.1, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
+      <HintPath>..\packages\FSharp.Compiler.CodeDom.1.0.0.1\lib\net40\FSharp.Compiler.CodeDom.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nunit.core, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">

--- a/Tests/packages.config
+++ b/Tests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FSharp.Compiler.CodeDom" version="0.9.3.0" targetFramework="net45" />
+  <package id="FSharp.Compiler.CodeDom" version="1.0.0.1" targetFramework="net45" />
   <package id="Microsoft.Net.Compilers" version="1.0.0" targetFramework="net45" developmentDependency="true" />
   <package id="NUnit" version="2.6.4" targetFramework="net4" />
   <package id="NUnitTestAdapter" version="2.0.0" targetFramework="net4" />


### PR DESCRIPTION
Fixed clean build/rebuild under Visual Studio (problem was introduced when I've updated ILSpy).
Updated some NuGet packages to their latest verions.