### PR TITLE
Array JSON.stringify interop fixed

### DIFF
--- a/JSIL.Libraries/Sources/JSIL.Core.js
+++ b/JSIL.Libraries/Sources/JSIL.Core.js
@@ -9414,7 +9414,7 @@ JSIL.Array.New = function Array_New (elementType, sizeOrInitializer) {
     result = new Array(size);
   }
 
-  result.__ElementType__ = elementTypeObject;
+  JSIL.SetValueProperty(result, "__ElementType__", elementTypeObject, false, true);
 
   if (initializerIsArray) {
     // If non-numeric, assume array initializer


### PR DESCRIPTION
Use `JSIL.SetValueProperty` for `"__ElementType__"` array property.
It restore functionality of JSON.stringify with JSIL-created arrays (as `__ElementType__` mark as non-enumerable)