### PR TITLE
TypeScript DefinitelyTyped support

### DIFF
--- a/Compiler/Configuration.cs
+++ b/Compiler/Configuration.cs
@@ -43,7 +43,6 @@ namespace JSIL.Compiler {
         public bool? ReuseTypeInfoAcrossAssemblies;
         public bool? ProxyWarnings;
         public string OutputDirectory;
-        public string OutputFileName;
         public string FileOutputDirectory;
         public string Profile;
         public Dictionary<string, object> ProfileSettings = new Dictionary<string, object>();
@@ -67,8 +66,6 @@ namespace JSIL.Compiler {
                 cc.ReuseTypeInfoAcrossAssemblies = ReuseTypeInfoAcrossAssemblies;
             if (OutputDirectory != null)
                 cc.OutputDirectory = OutputDirectory;
-            if (OutputFileName != null)
-                cc.OutputFileName = OutputFileName;
             if (FileOutputDirectory != null)
                 cc.FileOutputDirectory = FileOutputDirectory;
             if (Profile != null)

--- a/Compiler/Extensibility/IProfile.cs
+++ b/Compiler/Extensibility/IProfile.cs
@@ -13,15 +13,14 @@ namespace JSIL.Compiler.Extensibility {
         Configuration GetConfiguration (
             Configuration defaultConfiguration
         );
-        TranslationResult Translate (
+        TranslationResultCollection Translate (
             VariableSet variables, AssemblyTranslator translator, 
             Configuration configuration, string assemblyPath, bool scanForProxies
         );
-        void ProcessSkippedAssembly (
-            Configuration configuration, string assemblyPath, TranslationResult result
-        );
         void WriteOutputs (
-            VariableSet variables, TranslationResult result, string path, string manifestPrefix, bool quiet
+            VariableSet variables, TranslationResultCollection result, string path, bool quiet
         );
+
+        void RegisterPostprocessors (IEnumerable<IEmitterGroupFactory> emitters, Configuration configuration, string assemblyPath, string[] skippedAssemblies);
     }
 }

--- a/Compiler/Profiles/Default.cs
+++ b/Compiler/Profiles/Default.cs
@@ -7,38 +7,11 @@ using JSIL.Compiler.Extensibility;
 using JSIL.Utilities;
 
 namespace JSIL.Compiler.Profiles {
-    public class Default : BaseProfile {
+    public class Default : BaseJavaScriptProfile
+    {
         public override bool IsAppropriateForSolution (SolutionBuilder.BuildResult buildResult) {
             // Normally we'd return true so that this profile is always selected, but this is our fallback profile.
             return false;
-        }
-
-        public override TranslationResult Translate (
-            VariableSet variables, 
-            AssemblyTranslator translator, 
-            Configuration configuration, 
-            string assemblyPath, 
-            bool scanForProxies
-        ) {
-            var result = translator.Translate(assemblyPath, scanForProxies);
-
-            PostProcessAllTranslatedAssemblies(configuration, assemblyPath, result);
-
-            return result;
-        }
-
-        public override void ProcessSkippedAssembly (
-            Configuration configuration, string assemblyPath, TranslationResult result
-        ) {
-            PostProcessAssembly(configuration, assemblyPath, result);
-        }
-
-        public override SolutionBuilder.BuildResult ProcessBuildResult (VariableSet variables, Configuration configuration, SolutionBuilder.BuildResult buildResult) {
-            CopiedOutputGatherer.GatherFromProjectFiles(
-                variables, configuration, buildResult
-            );
-
-            return base.ProcessBuildResult(variables, configuration, buildResult);
         }
     }
 }

--- a/Compiler/Profiles/XNA4/XNA4Profile.cs
+++ b/Compiler/Profiles/XNA4/XNA4Profile.cs
@@ -12,7 +12,8 @@ using Microsoft.Build.Evaluation;
 using Microsoft.Xna.Framework;
 
 namespace JSIL.Compiler.Profiles {
-    public class XNA4 : BaseProfile {
+    public class XNA4 : BaseJavaScriptProfile
+    {
         public HashSet<string> ContentProjectsProcessed = new HashSet<string>();
 
         public override bool IsAppropriateForSolution (SolutionBuilder.BuildResult buildResult) {
@@ -30,24 +31,9 @@ namespace JSIL.Compiler.Profiles {
             return (Configuration)result;
         }
 
-        public override TranslationResult Translate (
-            VariableSet variables, AssemblyTranslator translator, Configuration configuration, string assemblyPath, bool scanForProxies
-        ) {
-            var result = translator.Translate(assemblyPath, scanForProxies);
-
-            PostProcessAllTranslatedAssemblies(configuration, assemblyPath, result);
-
-            result.AddFile("Script", "XNA.Colors.js", new ArraySegment<byte>(Encoding.UTF8.GetBytes(
-                Common.MakeXNAColors()
-            )), 0);
-
-            return result;
-        }
-
-        public override void ProcessSkippedAssembly (
-            Configuration configuration, string assemblyPath, TranslationResult result
-        ) {
-            PostProcessAssembly(configuration, assemblyPath, result);
+        protected override void PostProcessAllTranslatedAssemblies (Configuration configuration, string assemblyPath, TranslationResult result) {
+            base.PostProcessAllTranslatedAssemblies(configuration, assemblyPath, result);
+            result.AddFile("Script", "XNA.Colors.js", new ArraySegment<byte>(Encoding.UTF8.GetBytes(Common.MakeXNAColors())), 0);
         }
 
         public override SolutionBuilder.BuildResult ProcessBuildResult (

--- a/JSIL.mscorlib/JSIL.mscorlib.dll.jsilconfig
+++ b/JSIL.mscorlib/JSIL.mscorlib.dll.jsilconfig
@@ -1,6 +1,9 @@
 ﻿{
-  "OutputFileName": "../../JSIL.Libraries/Generated/JSIL.mscorlib.js",
-  "OutputDirectory": "%AssemblyDirectory%",
+  "OutputDirectory": "%AssemblyDirectory%/../../JSIL.Libraries/Generated/",
   "IncludeDependencies": false,
-  "MonoFixConfig" :  {}
+  "SkipManifestCreation": true,
+  "FilenameReplaceRegexes": {
+    ", Version(.*)\\.js$": ".js"
+  },
+  "MonoFixConfig": { }
 }

--- a/JSIL.mscorlib/JSIL.mscorlib.dll.jsilconfig
+++ b/JSIL.mscorlib/JSIL.mscorlib.dll.jsilconfig
@@ -3,7 +3,7 @@
   "IncludeDependencies": false,
   "SkipManifestCreation": true,
   "FilenameReplaceRegexes": {
-    ", Version(.*)\\.js$": ".js"
+    ", Version(.*)$": ""
   },
   "MonoFixConfig": { }
 }

--- a/JSIL.mscorlib/Properties/AssemblyInfo.cs
+++ b/JSIL.mscorlib/Properties/AssemblyInfo.cs
@@ -35,5 +35,5 @@ using JSIL.Meta;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
-[assembly: JSRepaceAssemblyDeclaration("$jsilcore")]
-[assembly: JSOverrideAssemblyReference(typeof(object), "$jsilcore")]
+[assembly: JSRepaceAssemblyDeclaration("mscorlib")]
+[assembly: JSOverrideAssemblyReference(typeof(object), "mscorlib")]

--- a/JSIL/AssemblyTranslator.cs
+++ b/JSIL/AssemblyTranslator.cs
@@ -420,14 +420,15 @@ namespace JSIL {
         }
 
         protected virtual string FormatOutputFilename (string fileName) {
+            var name = Path.GetFileNameWithoutExtension(fileName);
             foreach (var filenameReplaceRegex in Configuration.FilenameReplaceRegexes) {
-                fileName = Regex.Replace(fileName, filenameReplaceRegex.Key, filenameReplaceRegex.Value);
+                name = Regex.Replace(name, filenameReplaceRegex.Key, filenameReplaceRegex.Value);
             }
 
             if (Configuration.FilenameEscapeRegex != null)
-                return Regex.Replace(fileName, Configuration.FilenameEscapeRegex, "_");
-            else
-                return fileName;
+                name = Regex.Replace(name, Configuration.FilenameEscapeRegex, "_");
+
+            return Path.Combine(Path.GetDirectoryName(fileName), name + Path.GetExtension(fileName));
         }
 
         public TranslationResultCollection Translate (

--- a/JSIL/AssemblyTranslator.cs
+++ b/JSIL/AssemblyTranslator.cs
@@ -101,10 +101,8 @@ namespace JSIL {
         public event Action<TypeIdentifier> ProxyNotMatched;
         public event Action<QualifiedMemberIdentifier> ProxyMemberNotMatched;
 
-        public Func<bool, string, string> ChooseCustomAssemblyName;
-
         public readonly TypeInfoProvider TypeInfoProvider;
-        public readonly IEmitterFactory EmitterFactory;
+        public readonly IEmitterGroupFactory[] EmitterGroupFactories;
 
         protected bool OwnsAssemblyDataResolver;
         protected bool OwnsTypeInfoProvider;
@@ -115,17 +113,21 @@ namespace JSIL {
             AssemblyManifest manifest = null,
             AssemblyDataResolver assemblyDataResolver = null,
             AssemblyLoadedHandler onProxyAssemblyLoaded = null,
-            IEmitterFactory emitterFactory = null,
-            IEnumerable<IAnalyzer> analyzers = null
-        ) {
+            IEnumerable<IAnalyzer> analyzers = null,
+            IEmitterGroupFactory[] emitterGroupFactories = null
+        )
+        {
             ProxyAssemblyLoaded = onProxyAssemblyLoaded;
             Warning = (s) =>
                 Console.Error.WriteLine("// {0}", s);
 
             Manifest = manifest ?? new AssemblyManifest();
-            EmitterFactory = emitterFactory ?? new JavascriptEmitterFactory();
+            EmitterGroupFactories = emitterGroupFactories ?? new IEmitterGroupFactory[] { new JavascriptEmitterGroupFactory() };
 
-            Configuration = EmitterFactory.FilterConfiguration(configuration);
+            foreach (var emitterFactory in EmitterGroupFactories) {
+                //TODO: Split FilterConfiguration from IEmitterGroupFactory
+                Configuration = emitterFactory.FilterConfiguration(configuration);
+            }
             bool useDefaultProxies = configuration.UseDefaultProxies.GetValueOrDefault(true);
 
             OwnsAssemblyDataResolver = (assemblyDataResolver == null);
@@ -136,7 +138,10 @@ namespace JSIL {
             if (analyzers != null)
                 analyzerList.AddRange(analyzers);
 
-            analyzerList.AddRange(EmitterFactory.GetAnalyzers());
+            foreach (var emitterFactory in EmitterGroupFactories) {
+                //TODO: Split GetAnalyzers from IEmitterGroupFactory
+                analyzerList.AddRange(emitterFactory.GetAnalyzers());
+            }
 
             if (typeInfoProvider != null) {
                 TypeInfoProvider = typeInfoProvider;
@@ -414,15 +419,18 @@ namespace JSIL {
             };
         }
 
-        protected virtual string FormatOutputFilename (AssemblyNameDefinition assemblyName) {
-            var result = assemblyName.ToString();
+        protected virtual string FormatOutputFilename (string fileName) {
+            foreach (var filenameReplaceRegex in Configuration.FilenameReplaceRegexes) {
+                fileName = Regex.Replace(fileName, filenameReplaceRegex.Key, filenameReplaceRegex.Value);
+            }
+
             if (Configuration.FilenameEscapeRegex != null)
-                return Regex.Replace(result, Configuration.FilenameEscapeRegex, "_");
+                return Regex.Replace(fileName, Configuration.FilenameEscapeRegex, "_");
             else
-                return result;
+                return fileName;
         }
 
-        public TranslationResult Translate (
+        public TranslationResultCollection Translate (
             string assemblyPath, bool scanForProxies = true
         ) {
             var originalLatencyMode = System.Runtime.GCSettings.LatencyMode;
@@ -450,10 +458,15 @@ namespace JSIL {
             }
         }
 
-        private TranslationResult TranslateInternal (
+        private TranslationResultCollection TranslateInternal (
             string assemblyPath, bool scanForProxies = true
         ) {
-            var result = new TranslationResult(this.Configuration, assemblyPath, Manifest);
+            var result = new TranslationResultCollection();
+            var results = EmitterGroupFactories.Select(item => new {EmitterGroup = item, TranslationResult = new TranslationResult(this.Configuration, assemblyPath, Manifest)}).ToList();
+            foreach (var pairs in results) {
+                result.TranslationResults.Add(pairs.TranslationResult);
+            }
+
             var assemblies = new [] {assemblyPath}.Union(this.Configuration.Assemblies.TranslateAdditional).Distinct()
                 .SelectMany(LoadAssembly).Distinct(new FullNameAssemblyComparer()).ToArray();
             var parallelOptions = GetParallelOptions();
@@ -514,47 +527,47 @@ namespace JSIL {
 
             Action<int> writeAssembly = (i) => {
                 var assembly = assemblies[i];
+                bool stubbed = IsStubbed(assembly);
 
-                string outputPath = null;
+                foreach (var pair in results) {
+                    long existingSize;
+                    foreach (var emmitterFactory in pair.EmitterGroup.MakeAssemblyEmitterFactory(this, assembly)) {
+                        var outputPath = FormatOutputFilename(emmitterFactory.AssemblyPathAndFilename);
+                        if (!Manifest.GetExistingSize(assembly, emmitterFactory.Id, out existingSize)) {
+                            using (var outputStream = new MemoryStream(DefaultStreamCapacity)) {
+                                var sourceMapBuilder = Configuration.BuildSourceMap.GetValueOrDefault() ? new SourceMapBuilder() : null;
+                                var context = MakeDecompilerContext(assembly.MainModule);
 
-                if (ChooseCustomAssemblyName != null)
-                    outputPath = ChooseCustomAssemblyName(
-                        i == 0, assembly.Name.ToString()
-                    );
-                if (outputPath == null)
-                    outputPath = FormatOutputFilename(assembly.Name) + EmitterFactory.FileExtension;
+                                try {
+                                    var tw = new StreamWriter(outputStream, Encoding.ASCII);
+                                    var formatter = new JavascriptFormatter(tw, sourceMapBuilder, this.TypeInfoProvider, Manifest, assembly, Configuration, stubbed);
+                                    var emitter = emmitterFactory.MakeAssemblyEmitter(formatter);
+                                    TranslateSingleAssemblyInternal(emitter, context, assembly, outputStream, sourceMapBuilder);
+                                    tw.Flush();
+                                }
+                                catch (Exception exc) {
+                                    throw new Exception("Error occurred while generating javascript for assembly '" + assembly.FullName + "'.", exc);
+                                }
+                                var segment = new ArraySegment<byte>(
+                                    outputStream.GetBuffer(), 0, (int) outputStream.Length
+                                    );
 
-                long existingSize;
+                                pair.TranslationResult.AddFile(emmitterFactory.ArtifactType, outputPath, segment, sourceMapBuilder: sourceMapBuilder);
 
-                if (!Manifest.GetExistingSize(assembly, out existingSize)) {
-                    using (var outputStream = new MemoryStream(DefaultStreamCapacity)) {
-                        var sourceMapBuilder = Configuration.BuildSourceMap.GetValueOrDefault() ? new SourceMapBuilder() : null;
-                        var context = MakeDecompilerContext(assembly.MainModule);
+                                Manifest.SetAlreadyTranslated(assembly, emmitterFactory.Id, outputStream.Length);
+                            }
 
-                        try {
-                            TranslateSingleAssemblyInternal(context, assembly, outputStream, sourceMapBuilder);
-                        } catch (Exception exc) {
-                            throw new Exception("Error occurred while generating javascript for assembly '" + assembly.FullName + "'.", exc);
+                            lock (pair.TranslationResult.Assemblies)
+                                pair.TranslationResult.Assemblies.Add(assembly);
+                        } else {
+                            Console.WriteLine("Skipping '{0}' because it is already translated...", assembly.Name);
+
+                            pair.TranslationResult.AddExistingFile(emmitterFactory.ArtifactType, outputPath, existingSize);
                         }
-
-                        var segment = new ArraySegment<byte>(
-                            outputStream.GetBuffer(), 0, (int)outputStream.Length
-                        );
-
-                        result.AddFile("Script", outputPath, segment, sourceMapBuilder:sourceMapBuilder);
-
-                        Manifest.SetAlreadyTranslated(assembly, outputStream.Length);
+                    //TODO!
+                    //pr.OnProgressChanged(translationResultFactory.Item2.Assemblies.Count, assemblies.Length);
                     }
-
-                    lock (result.Assemblies)
-                        result.Assemblies.Add(assembly);
-                } else {
-                    Console.WriteLine("Skipping '{0}' because it is already translated...", assembly.Name);
-
-                    result.AddExistingFile("Script", outputPath, existingSize);
                 }
-
-                pr.OnProgressChanged(result.Assemblies.Count, assemblies.Length);
             };
 
             if (Configuration.UseThreads.GetValueOrDefault(false)) {
@@ -571,6 +584,10 @@ namespace JSIL {
             pr.OnFinished();
 
             DoProxyDiagnostics();
+
+            foreach (var pair in results) {
+                pair.EmitterGroup.RunPostprocessors(Manifest, assemblyPath, pair.TranslationResult);
+            }
 
             return result;
         }
@@ -650,65 +667,8 @@ namespace JSIL {
 #endif
         }
 
-        public static void GenerateManifest (AssemblyManifest manifest, string assemblyPath, TranslationResult result) {
-            using (var ms = new MemoryStream())
-            using (var tw = new StreamWriter(ms, new UTF8Encoding(false))) {
-                tw.WriteLine("// {0} {1}", GetHeaderText(), Environment.NewLine);
-                tw.WriteLine("'use strict';");
 
-                foreach (var kvp in manifest.Entries) {
-                    tw.WriteLine(
-                        "var {0} = JSIL.GetAssembly({1});",
-                        kvp.Key, Util.EscapeString(kvp.Value, '\"')
-                    );
-                }
 
-                if (result.Configuration.GenerateContentManifest.GetValueOrDefault(true)) {
-                    tw.WriteLine();
-                    tw.WriteLine("if (typeof (contentManifest) !== \"object\") { JSIL.GlobalNamespace.contentManifest = {}; };");
-                    tw.WriteLine("contentManifest[\"" + Path.GetFileName(assemblyPath).Replace("\\", "\\\\") + "\"] = [");
-
-                    foreach (var fe in result.OrderedFiles) {
-                        var propertiesObject = FormatFileProperties(fe);
-
-                        tw.WriteLine(String.Format(
-                            "    [{0}, {1}, {2}],",
-                            Util.EscapeString(fe.Type), 
-                            Util.EscapeString(fe.Filename.Replace("\\", "/")), 
-                            propertiesObject
-                        ));
-                    }
-
-                    tw.WriteLine("];");
-                }
-
-                tw.Flush();
-
-                result.Manifest = new ArraySegment<byte>(
-                    ms.GetBuffer(), 0, (int)ms.Length
-                );
-            }
-        }
-
-        private static string FormatFileProperties (TranslationResult.ResultFile fe) {
-            var result = "{ ";
-            result += "\"sizeBytes\": ";
-            result += fe.Size;
-
-            if (fe.Properties != null)
-            foreach (var kvp in fe.Properties) {
-                result += ", \"" + kvp.Key + "\": ";
-
-                if (kvp.Value is string)
-                    result += Util.EscapeString((string)kvp.Value, forJson: true);
-                else
-                    throw new NotImplementedException("File property of type '" + kvp.Value.GetType().Name);
-            }
-
-            result += " }";
-
-            return result;
-        }
 
         private void AnalyzeFunctions (
             ParallelOptions parallelOptions, AssemblyDefinition[] assemblies,
@@ -880,8 +840,15 @@ namespace JSIL {
         }
 
         public bool IsIgnored (AssemblyDefinition assembly) {
-            foreach (var sa in Configuration.Assemblies.Ignored) {
-                if (Regex.IsMatch(assembly.FullName, sa, RegexOptions.IgnoreCase)) {
+            return IsIgnoredAssembly(assembly.FullName);
+        }
+
+        public bool IsIgnoredAssembly(string assemblyName)
+        {
+            foreach (var sa in Configuration.Assemblies.Ignored)
+            {
+                if (Regex.IsMatch(assemblyName, sa, RegexOptions.IgnoreCase))
+                {
                     return true;
                 }
             }
@@ -907,10 +874,8 @@ namespace JSIL {
             );
         }
 
-        protected void TranslateSingleAssemblyInternal (DecompilerContext context, AssemblyDefinition assembly, Stream outputStream, SourceMapBuilder sourceMapBuilder) {
+        protected void TranslateSingleAssemblyInternal (IAssemblyEmitter assemblyEmitter, DecompilerContext context, AssemblyDefinition assembly, Stream outputStream, SourceMapBuilder sourceMapBuilder) {
             bool stubbed = IsStubbed(assembly);
-
-            var tw = new StreamWriter(outputStream, Encoding.ASCII);
 
             string assemblyDeclarationReplacement = null;
             var metadata = new MetadataCollection(assembly);
@@ -925,11 +890,12 @@ namespace JSIL {
             {
                 assemblies = assembly.Modules
                     .SelectMany(item => item.AssemblyReferences)
-                    .Select(item => ResolveRedirectedName(item.FullName))
+                    .Select(item => AssemblyDataResolver.AssemblyResolver.Resolve(item))
+                    .Where(item => item != null)
                     .Distinct()
                     .ToDictionary(
                         item => Manifest.GetPrivateToken(item),
-                        item => string.Format("JSIL.GetAssembly({0})", Util.EscapeString(item, '\"')));
+                        item => item.FullName);
 
                 assemblies.Remove(Manifest.GetPrivateToken(assembly.FullName));
             }
@@ -948,15 +914,13 @@ namespace JSIL {
                 assemblies[pair.Key] = pair.Value;
             }
 
+            Manifest.AssignIdentifiers();
+
             wrapAssemblyInImmediatelyInvokedFunctionExpression |= assemblies.Count > 0;
+            assemblies = wrapAssemblyInImmediatelyInvokedFunctionExpression ? assemblies : null;
 
-            var formatter = new JavascriptFormatter(
-                tw, sourceMapBuilder, this.TypeInfoProvider, Manifest, assembly, Configuration, assemblyDeclarationReplacement, stubbed
-            );
-
-            var assemblyEmitter = EmitterFactory.MakeAssemblyEmitter(this, assembly, formatter, wrapAssemblyInImmediatelyInvokedFunctionExpression ? assemblies : null);
-
-            assemblyEmitter.EmitHeader(stubbed);
+            assemblyEmitter.EmitHeader(stubbed, wrapAssemblyInImmediatelyInvokedFunctionExpression);
+            assemblyEmitter.EmitAssemblyReferences(assemblyDeclarationReplacement, assemblies);
 
             if (assembly.EntryPoint != null)
                 TranslateEntryPoint(assemblyEmitter, assembly);
@@ -975,9 +939,7 @@ namespace JSIL {
 
             TranslateImportedTypes(assembly, assemblyEmitter, declaredTypes, stubbed);
 
-            assemblyEmitter.EmitFooter();
-
-            tw.Flush();
+            assemblyEmitter.EmitFooter(wrapAssemblyInImmediatelyInvokedFunctionExpression);
         }
 
         protected void TranslateEntryPoint (
@@ -2207,30 +2169,236 @@ namespace JSIL {
         }
     }
 
-    public class JavascriptEmitterFactory : IEmitterFactory {
-        public string FileExtension {
-            get {
-                return ".js";
-            }
+    public abstract class BaseEmitterGroupFactory : IEmitterGroupFactory {
+        private Action<TranslationResult> _postprocessors;
+
+        public void RegisterPostprocessor (Action<TranslationResult> action) {
+            _postprocessors += action;
         }
 
-        public IAssemblyEmitter MakeAssemblyEmitter (
-            AssemblyTranslator assemblyTranslator,
-            AssemblyDefinition assembly,
-            JavascriptFormatter formatter,
-            IDictionary<AssemblyManifest.Token, string> referenceOverrides
-        ) {
-            return new JavascriptAssemblyEmitter(
-                assemblyTranslator, formatter, referenceOverrides
-            );
+        public virtual void RunPostprocessors (AssemblyManifest manifest, string assemblyPath, TranslationResult result) {
+            if (_postprocessors != null)
+                _postprocessors(result);
         }
 
-        public IEnumerable<IAnalyzer> GetAnalyzers () {
+        public abstract IEnumerable<IAssemblyEmmitterFactory> MakeAssemblyEmitterFactory (AssemblyTranslator assemblyTranslator, AssemblyDefinition assembly);
+        public virtual IEnumerable<IAnalyzer> GetAnalyzers()
+        {
             yield break;
         }
 
-        public Configuration FilterConfiguration (Configuration configuration) {
+        public virtual Configuration FilterConfiguration(Configuration configuration)
+        {
             return configuration;
+        }
+    }
+
+    public class JavascriptEmitterGroupFactory : BaseEmitterGroupFactory {
+        private const string TranslatorId = "JS";
+
+        public override IEnumerable<IAssemblyEmmitterFactory> MakeAssemblyEmitterFactory (AssemblyTranslator assemblyTranslator, AssemblyDefinition assembly) {
+            return new IAssemblyEmmitterFactory[] {new JavascriptAssemblyEmmitterFactory(assemblyTranslator, assembly)};
+        }
+
+        public override void RunPostprocessors (AssemblyManifest manifest, string assemblyPath, TranslationResult result) {
+            base.RunPostprocessors(manifest, assemblyPath, result);
+            if (!result.Configuration.SkipManifestCreation.GetValueOrDefault(false)) {
+                GenerateManifest(manifest, assemblyPath, result);
+            }
+        }
+
+        private static void GenerateManifest (AssemblyManifest manifest, string assemblyPath, TranslationResult result) {
+            using (var ms = new MemoryStream())
+            using (var tw = new StreamWriter(ms, new UTF8Encoding(false))) {
+                tw.WriteLine("// {0} {1}", AssemblyTranslator.GetHeaderText(), Environment.NewLine);
+                tw.WriteLine("'use strict';");
+
+                foreach (var kvp in manifest.Entries) {
+                    tw.WriteLine(
+                        "var {0} = JSIL.GetAssembly({1});",
+                        kvp.Key, Util.EscapeString(kvp.Value, '\"')
+                        );
+                }
+
+                if (result.Configuration.GenerateContentManifest.GetValueOrDefault(true)) {
+                    tw.WriteLine();
+                    tw.WriteLine("if (typeof (contentManifest) !== \"object\") { JSIL.GlobalNamespace.contentManifest = {}; };");
+                    tw.WriteLine("contentManifest[\"" + Path.GetFileName(assemblyPath).Replace("\\", "\\\\") + "\"] = [");
+
+                    foreach (var fe in result.OrderedFiles) {
+                        var propertiesObject = FormatFileProperties(fe);
+
+                        tw.WriteLine(String.Format(
+                            "    [{0}, {1}, {2}],",
+                            Util.EscapeString(fe.Type),
+                            Util.EscapeString(fe.Filename.Replace("\\", "/")),
+                            propertiesObject
+                            ));
+                    }
+
+                    tw.WriteLine("];");
+                }
+
+                tw.Flush();
+
+                result.AddFile("Manifest", Path.GetFileName(assemblyPath) + ".manifest.js", new ArraySegment<byte>(ms.GetBuffer(), 0, (int) ms.Length), 0);
+            }
+        }
+
+        private static string FormatFileProperties (TranslationResult.ResultFile fe) {
+            var result = "{ ";
+            result += "\"sizeBytes\": ";
+            result += fe.Size;
+
+            if (fe.Properties != null)
+                foreach (var kvp in fe.Properties) {
+                    result += ", \"" + kvp.Key + "\": ";
+
+                    if (kvp.Value is string)
+                        result += Util.EscapeString((string) kvp.Value, forJson: true);
+                    else
+                        throw new NotImplementedException("File property of type '" + kvp.Value.GetType().Name);
+                }
+
+            result += " }";
+
+            return result;
+        }
+
+        public class JavascriptAssemblyEmmitterFactory : IAssemblyEmmitterFactory {
+            private readonly AssemblyTranslator assemblyTranslator;
+            private readonly AssemblyDefinition assembly;
+
+            public JavascriptAssemblyEmmitterFactory (AssemblyTranslator assemblyTranslator, AssemblyDefinition assembly) {
+                this.assemblyTranslator = assemblyTranslator;
+                this.assembly = assembly;
+            }
+
+            public string Id {
+                get { return TranslatorId; }
+            }
+
+            public string AssemblyPathAndFilename {
+                get { return assembly.FullName + ".js"; }
+            }
+
+            public string ArtifactType {
+                get { return "Script"; }
+            }
+
+            public IAssemblyEmitter MakeAssemblyEmitter (JavascriptFormatter formatter) {
+                return new JavascriptAssemblyEmitter(assemblyTranslator, formatter);
+            }
+        }
+    }
+
+
+    public class DefinitelyTypedEmitterGroupFactory : BaseEmitterGroupFactory {
+        private const string TranslatorId = "D-TS";
+
+        public override Configuration FilterConfiguration(Configuration configuration) {
+            configuration.InlineAssemblyReferences = true;
+            return configuration;
+        }
+
+        public override IEnumerable<IAssemblyEmmitterFactory> MakeAssemblyEmitterFactory(AssemblyTranslator assemblyTranslator, AssemblyDefinition assembly)
+        {
+            return new IAssemblyEmmitterFactory[] {
+                new DefinitelyTypedInternalsEmitterFactory(assemblyTranslator, assembly),
+                new DefinitelyTypedExportEmitterFactory(assemblyTranslator, assembly),
+                new DefinitelyTypedModuleEmitterFactory(assemblyTranslator, assembly), 
+            };
+        }
+
+        public override void RunPostprocessors(AssemblyManifest manifest, string assemblyPath, TranslationResult result)
+        {
+            base.RunPostprocessors(manifest, assemblyPath, result);
+            var jsilPath = Path.GetDirectoryName(JSIL.Internal.Util.GetPathOfAssembly(Assembly.GetExecutingAssembly()));
+            var searchPath = Path.Combine(jsilPath, "JS Libraries\\DefinitelyTyped\\");
+            foreach (var file in Directory.GetFiles(searchPath, "*", SearchOption.AllDirectories)) {
+                var bytes = File.ReadAllBytes(file);
+                result.AddFile("common",
+                    new Uri(searchPath).MakeRelativeUri(new Uri(file)).ToString(),
+                    new ArraySegment<byte>(bytes));
+            }
+        }
+
+        public class DefinitelyTypedInternalsEmitterFactory : IAssemblyEmmitterFactory
+        {
+            private AssemblyTranslator assemblyTranslator;
+            private AssemblyDefinition assembly;
+
+            public DefinitelyTypedInternalsEmitterFactory(AssemblyTranslator assemblyTranslator, AssemblyDefinition assembly)
+            {
+                this.assemblyTranslator = assemblyTranslator;
+                this.assembly = assembly;
+            }
+
+            public string Id { get { return TranslatorId + "/Internals"; ; } }
+
+            public string AssemblyPathAndFilename
+            {
+                get { return "internals/" + assembly.FullName + ".d.ts"; }
+            }
+
+            public string ArtifactType { get { return Id; } }
+
+            public IAssemblyEmitter MakeAssemblyEmitter(JavascriptFormatter formatter)
+            {
+                return new DefinitelyTypedInternalsEmitter(assemblyTranslator, formatter);
+            }
+        }
+
+        public class DefinitelyTypedExportEmitterFactory : IAssemblyEmmitterFactory
+        {
+            private AssemblyTranslator assemblyTranslator;
+            private AssemblyDefinition assembly;
+
+            public DefinitelyTypedExportEmitterFactory(AssemblyTranslator assemblyTranslator, AssemblyDefinition assembly)
+            {
+                this.assemblyTranslator = assemblyTranslator;
+                this.assembly = assembly;
+            }
+
+            public string Id { get { return TranslatorId + "/Exports"; ; } }
+
+            public string AssemblyPathAndFilename
+            {
+                get { return "module." + assembly.FullName + ".d.ts"; }
+            }
+
+            public string ArtifactType { get { return Id; } }
+
+            public IAssemblyEmitter MakeAssemblyEmitter(JavascriptFormatter formatter)
+            {
+                return new DefinitelyTypedExportEmitter(assemblyTranslator, formatter);
+            }
+        }
+
+        public class DefinitelyTypedModuleEmitterFactory : IAssemblyEmmitterFactory
+        {
+            private AssemblyTranslator assemblyTranslator;
+            private AssemblyDefinition assembly;
+
+            public DefinitelyTypedModuleEmitterFactory(AssemblyTranslator assemblyTranslator, AssemblyDefinition assembly)
+            {
+                this.assemblyTranslator = assemblyTranslator;
+                this.assembly = assembly;
+            }
+
+            public string Id { get { return TranslatorId + "/Module"; ; } }
+
+            public string AssemblyPathAndFilename
+            {
+                get { return "module." + assembly.FullName + ".js"; }
+            }
+
+            public string ArtifactType { get { return Id; } }
+
+            public IAssemblyEmitter MakeAssemblyEmitter(JavascriptFormatter formatter)
+            {
+                return new DefinitelyTypedModuleEmitter(assemblyTranslator, formatter);
+            }
         }
     }
 }

--- a/JSIL/Configuration.cs
+++ b/JSIL/Configuration.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Runtime.Serialization;
-using System.Text.RegularExpressions;
 
 namespace JSIL.Translator {
     [Serializable]
@@ -124,12 +122,14 @@ namespace JSIL.Translator {
         public bool? UseThreads;
         public bool? UseDefaultProxies;
         public bool? GenerateSkeletonsForStubbedAssemblies;
+        public bool? SkipManifestCreation;
         public bool? GenerateContentManifest;
         public bool? RunBugChecks;
         public bool? TuneGarbageCollection;
         public string FilenameEscapeRegex;
+        public Dictionary<string, string> FilenameReplaceRegexes = new Dictionary<string, string>();
         public string AssemblyCollectionName;
-        public string EmitterFactoryName;
+        public List<string> EmitterFactories = new List<string>();
         public bool? BuildSourceMap;
         public bool? InlineAssemblyReferences;
 
@@ -162,6 +162,8 @@ namespace JSIL.Translator {
                 result.GenerateSkeletonsForStubbedAssemblies = GenerateSkeletonsForStubbedAssemblies;
             if (GenerateContentManifest.HasValue)
                 result.GenerateContentManifest = GenerateContentManifest;
+            if (SkipManifestCreation.HasValue)
+                result.SkipManifestCreation = SkipManifestCreation;
             if (RunBugChecks.HasValue)
                 result.RunBugChecks = RunBugChecks;
             if (TuneGarbageCollection.HasValue)
@@ -171,14 +173,19 @@ namespace JSIL.Translator {
                 result.FilenameEscapeRegex = FilenameEscapeRegex;
             if (AssemblyCollectionName != null)
                 result.AssemblyCollectionName = AssemblyCollectionName;
-            if (EmitterFactoryName != null)
-                result.EmitterFactoryName = EmitterFactoryName;
 
             if (BuildSourceMap != null)
                 result.BuildSourceMap = BuildSourceMap;
 
             if (InlineAssemblyReferences != null)
                 result.InlineAssemblyReferences = InlineAssemblyReferences;
+
+            foreach (var kvp in FilenameReplaceRegexes)
+                result.FilenameReplaceRegexes[kvp.Key] = kvp.Value;
+
+            foreach (var emitterFactory in EmitterFactories) {
+                result.EmitterFactories.Add(emitterFactory);
+            }
 
             Assemblies.MergeInto(result.Assemblies);
             CodeGenerator.MergeInto(result.CodeGenerator);

--- a/JSIL/DefinitelyTypedAssemblyEmitter.cs
+++ b/JSIL/DefinitelyTypedAssemblyEmitter.cs
@@ -1,0 +1,806 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Globalization;
+using System.Linq;
+using ICSharpCode.Decompiler;
+using JSIL.Ast;
+using JSIL.Compiler.Extensibility;
+using JSIL.Internal;
+using JSIL.Transforms;
+using JSIL.Translator;
+using Mono.Cecil;
+using AssemblyDefinition = Mono.Cecil.AssemblyDefinition;
+using TypeDefinition = Mono.Cecil.TypeDefinition;
+using TypeInfo = JSIL.Internal.TypeInfo;
+
+namespace JSIL {
+
+    public class DefinitelyTypedInternalsEmitter : DefinitelyTypedBaseEmitter {
+        public readonly AssemblyTranslator Translator;
+
+        public DefinitelyTypedInternalsEmitter(
+            AssemblyTranslator assemblyTranslator,
+            JavascriptFormatter formatter) : base(formatter) {
+            Translator = assemblyTranslator;
+        }
+
+        public override void EmitHeader (bool stubbed, bool iife) {
+            Formatter.WriteRaw("import {$private as $asmJsilCore, StaticTypePair as $StaticTypePair, TypePair as $TypePair} from \"./JSIL.Core\"");
+            Formatter.NewLine();
+        }
+
+        public override void EmitAssemblyReferences (string assemblyDeclarationReplacement, Dictionary<AssemblyManifest.Token, string> assemblies) {
+            if (assemblies != null) {
+                foreach (var referenceOverride in assemblies) {
+                    if (!Translator.IsIgnoredAssembly(referenceOverride.Value)) {
+                        Formatter.WriteRaw(string.Format("import {{$private as {0}}} from \"./{1}\"", referenceOverride.Key.IDString, referenceOverride.Value));
+                        Formatter.Semicolon();
+                    }
+                }
+            }
+
+            Formatter.WriteRaw("export declare namespace $private");
+            Formatter.OpenBrace();
+        }
+
+        public override void EmitFooter (bool iife) {
+            Formatter.CloseBrace();
+        }
+
+        public override bool EmitTypeDeclarationHeader(DecompilerContext context, IAstEmitter astEmitter, TypeDefinition typedef, TypeInfo typeInfo)
+        {
+            if (!DefinitelyTypedUtilities.IsTypePublic(typedef))
+            {
+                return true;
+            }
+
+            Formatter.EmitInsideNamespace(typedef, false, isTopLevel => {
+                Formatter.WriteRaw("namespace");
+                Formatter.Space();
+                Formatter.Identifier(DefinitelyTypedUtilities.GetClassName(typedef));
+                Formatter.OpenBrace();
+                EmitClassInstance(typedef);
+                EmitClassType(typedef);
+                EmitClassStatic(typedef);
+                EmitClassFactory(typedef);
+                Formatter.CloseBrace();
+            });
+
+            Formatter.NewLine();
+
+            return true;
+        }
+
+        private void EmitClassInstance (TypeDefinition typedef) {
+            Formatter.WriteRaw("class");
+            Formatter.Space();
+            Formatter.WriteSelfReference(typedef, Facade.Instance);
+            Formatter.Space();
+            Formatter.OpenBrace();
+
+            Formatter.WriteRaw("private __$brand : any");
+            Formatter.Semicolon();
+
+            foreach (var genericParameter in DefinitelyTypedUtilities.BuildGenericParemetersMap(typedef.GenericParameters, null)) {
+                Formatter.WriteRaw("private");
+                Formatter.Space();
+                Formatter.Identifier("__$" + genericParameter + "_brand");
+                Formatter.Space();
+                Formatter.WriteRaw(":");
+                Formatter.Space();
+                Formatter.Identifier(DefinitelyTypedUtilities.GetGenericParameterInParameterName(genericParameter.Value));
+                Formatter.Semicolon();
+            }
+
+            if (!typedef.IsInterface) {
+                var instanceFields = typedef.Fields.Where(it => it.IsPublic && !it.IsStatic && !Translator.ShouldSkipMember(it)).OrderBy(md => md.Name);
+                foreach (var instanceField in instanceFields)
+                {
+                    EmitField(instanceField);
+                }
+
+                // TODO: We need filter them to not hide fields
+                var instanceProperties = typedef.Properties
+                .Where(it => !Translator.ShouldSkipMember(it) && !it.HasParameters && (
+                        (it.GetMethod != null && it.GetMethod.IsPublic &&!it.GetMethod.IsStatic && !Translator.ShouldSkipMember(it.GetMethod))
+                     || (it.SetMethod != null && it.SetMethod.IsPublic && !it.SetMethod.IsStatic && !Translator.ShouldSkipMember(it.SetMethod))))
+                     .OrderBy(md => md.Name);
+                foreach (var instanceProperty in instanceProperties)
+                {
+                    EmitProperty(instanceProperty);
+                }
+
+                var instanceMethods = typedef.Methods.Where(it => it.IsPublic && !it.IsStatic && !it.IsConstructor && !Translator.ShouldSkipMember(it)).OrderBy(md => md.Name);
+                foreach (var instanceMethod in instanceMethods) {
+                    EmitMethod(instanceMethod);
+                }
+            }
+
+            Formatter.CloseBrace();
+        }
+
+        private void EmitClassType (TypeDefinition typedef) {
+            Formatter.WriteRaw("type");
+            Formatter.Space();
+            Formatter.WriteSelfReference(typedef, Facade.Type);
+
+            Formatter.Space();
+            Formatter.WriteRaw("=");
+            Formatter.Space();
+
+            Formatter.WriteSelfReference(typedef, Facade.Instance);
+
+            if (typedef.IsClass && typedef.BaseType != null) {
+                Formatter.Space();
+                Formatter.WriteRaw("&");
+                Formatter.Space();
+                Formatter.WriteTypeReference(typedef.BaseType, typedef, JavascriptFormatterHelper.ReplaceMode.Type, false);
+            }
+
+            var interfaces = typedef.Interfaces.Where(it => DefinitelyTypedUtilities.IsTypePublic(it) && !Translator.ShouldSkipMember(it));
+            foreach (var iface in interfaces) {
+                Formatter.Space();
+                Formatter.WriteRaw("&");
+                Formatter.Space();
+                Formatter.WriteTypeReference(iface, typedef, JavascriptFormatterHelper.ReplaceMode.Type, false);
+            }
+
+            Formatter.Semicolon();
+        }
+
+        private void EmitClassStatic (TypeDefinition typedef) {
+            Formatter.WriteRaw("interface");
+            Formatter.Space();
+            Formatter.WriteSelfReference(typedef, Facade.Static);
+            Formatter.Space();
+            Formatter.WriteRaw("extends");
+            Formatter.Space();
+            Formatter.WriteRaw(typedef.IsAbstract && typedef.IsSealed ? "$StaticTypePair" : "$TypePair");
+            Formatter.WriteRaw("<");
+            Formatter.WriteSelfReference(typedef, Facade.Instance);
+            Formatter.Comma();
+            Formatter.WriteSelfReference(typedef, Facade.Type);
+            Formatter.WriteRaw(">");
+            Formatter.Space();
+            Formatter.OpenBrace();
+
+            var staticFields = typedef.Fields.Where(it => it.IsPublic && it.IsStatic && !Translator.ShouldSkipMember(it)).OrderBy(md => md.Name);
+            foreach (var staticField in staticFields)
+            {
+                EmitField(staticField);
+            }
+
+            // TODO: We need filter them to not hide fields
+            var staticProperties = typedef.Properties
+                .Where(it => !Translator.ShouldSkipMember(it) && !it.HasParameters && (
+                        (it.GetMethod != null && it.GetMethod.IsPublic && it.GetMethod.IsStatic && !Translator.ShouldSkipMember(it.GetMethod))
+                     || (it.SetMethod != null && it.SetMethod.IsPublic && it.SetMethod.IsStatic && !Translator.ShouldSkipMember(it.SetMethod))))
+                     .OrderBy(md => md.Name);
+            foreach (var staticProperty in staticProperties)
+            {
+                EmitProperty(staticProperty);
+            }
+
+            var constructors = typedef.Methods.Where(it => it.IsPublic && !it.IsStatic && it.IsConstructor && !Translator.ShouldSkipMember(it));
+            var staticMethods = typedef.Methods.Where(it => it.IsPublic && it.IsStatic && !it.IsConstructor && !Translator.ShouldSkipMember(it)).OrderBy(it => it.Name);
+            foreach (var method in constructors.Concat(staticMethods)) {
+                EmitMethod(method);
+            }
+
+            Formatter.CloseBrace();
+        }
+
+        private void EmitClassFactory (TypeDefinition typedef) {
+            if (typedef.GenericParameters.Count > 0) {
+                Formatter.WriteRaw("interface");
+                Formatter.Space();
+                Formatter.WriteSelfReference(typedef, Facade.Factory);
+                Formatter.Space();
+                Formatter.OpenBrace();
+                Formatter.Identifier("Of");
+                Formatter.WriteGenericMethodSignatureWithoutResultType(typedef.GenericParameters, null);
+                Formatter.Space();
+                Formatter.WriteRaw(":");
+                Formatter.Space();
+                Formatter.WriteSelfReference(typedef, Facade.Static);
+                Formatter.CloseBrace();
+            } else {
+                Formatter.WriteRaw("type");
+                Formatter.Space();
+                Formatter.WriteSelfReference(typedef, Facade.Factory);
+                Formatter.Space();
+                Formatter.WriteRaw("=");
+                Formatter.Space();
+                Formatter.WriteSelfReference(typedef, Facade.Static);
+                Formatter.Semicolon();
+            }
+        }
+
+        private void EmitField (FieldDefinition field) {
+            Formatter.Identifier(field.Name);
+            Formatter.Space();
+            Formatter.WriteRaw(":");
+            Formatter.Space();
+            Formatter.WriteTypeReference(field.FieldType, null, JavascriptFormatterHelper.ReplaceMode.Type);
+            Formatter.Semicolon();
+        }
+
+        private void EmitProperty(PropertyDefinition property)
+        {
+            Formatter.Identifier(property.Name);
+            Formatter.Space();
+            Formatter.WriteRaw(":");
+            Formatter.Space();
+            Formatter.WriteTypeReference(property.PropertyType, null, JavascriptFormatterHelper.ReplaceMode.Type);
+            Formatter.Semicolon();
+        }
+
+        private void EmitMethod (MethodDefinition method) {
+            if (method.IsConstructor) {
+                Formatter.WriteRaw("new");
+            } else {
+                Formatter.Identifier(method.Name);
+                if (method.GenericParameters.Count > 0) {
+                    Formatter.WriteGenericMethodSignatureWithoutResultType(method.GenericParameters, method.DeclaringType.GenericParameters);
+                    Formatter.Space();
+                    Formatter.WriteRaw(":");
+                    Formatter.Space();
+                }
+            }
+
+            Formatter.WriteRaw("(");
+            Formatter.CommaSeparatedList(method.Parameters, item => {
+                Formatter.Identifier(item.Name);
+                Formatter.Space();
+                Formatter.WriteRaw(":");
+                Formatter.Space();
+                Formatter.WriteTypeReference(item.ParameterType, null, JavascriptFormatterHelper.ReplaceMode.Instance);
+            });
+            Formatter.WriteRaw(")");
+            Formatter.Space();
+            Formatter.WriteRaw(method.GenericParameters.Count > 0 ? "=>" : ":");
+            Formatter.Space();
+
+            if (!method.IsConstructor) {
+                Formatter.WriteTypeReference(method.ReturnType, null, JavascriptFormatterHelper.ReplaceMode.Type);
+            } else {
+                Formatter.WriteSelfReference(method.DeclaringType, Facade.Type);
+            }
+
+            Formatter.Semicolon();
+        }
+    }
+
+    public class DefinitelyTypedExportEmitter : DefinitelyTypedBaseEmitter
+    {
+        public readonly AssemblyTranslator Translator;
+
+        public DefinitelyTypedExportEmitter(
+            AssemblyTranslator assemblyTranslator,
+            JavascriptFormatter formatter) : base(formatter)
+        {
+            Translator = assemblyTranslator;
+        }
+
+        public override void EmitHeader(bool stubbed, bool iife)
+        {
+            Formatter.WriteRaw(string.Format("import {{$private as $this}} from \"./internals/{0}\"", Formatter.Assembly.FullName));
+            Formatter.Semicolon();
+        }
+
+        public override bool EmitTypeDeclarationHeader(DecompilerContext context, IAstEmitter astEmitter, TypeDefinition typedef, TypeInfo typeInfo) {
+            if (!DefinitelyTypedUtilities.IsTypePublic(typedef))
+            {
+                return true;
+            }
+
+            Formatter.EmitInsideNamespace(typedef, true, isTopLevel => {
+                if (isTopLevel)
+                {
+                    Formatter.WriteRaw("export");
+                    Formatter.Space();
+                    Formatter.WriteRaw("declare");
+                    Formatter.Space();
+                }
+
+                Formatter.WriteRaw("let");
+                Formatter.Space();
+
+                Formatter.Identifier(DefinitelyTypedUtilities.GetClassName(typedef));
+                Formatter.Space();
+                Formatter.WriteRaw(":");
+                Formatter.Space();
+
+                Formatter.Identifier("$this");
+                Formatter.Dot();
+
+                foreach (var part in DefinitelyTypedUtilities.GetFullNamespace(typedef))
+                {
+                    Formatter.Identifier(part);
+                    Formatter.Dot();
+                }
+
+                Formatter.Identifier(DefinitelyTypedUtilities.GetClassName(typedef));
+                Formatter.Dot();
+                Formatter.Identifier("Factory");
+                Formatter.Semicolon();
+            });
+
+            return true;
+        }
+    }
+
+    public class DefinitelyTypedModuleEmitter : DefinitelyTypedBaseEmitter
+    {
+        public readonly AssemblyTranslator Translator;
+
+        public DefinitelyTypedModuleEmitter(
+            AssemblyTranslator assemblyTranslator,
+            JavascriptFormatter formatter) : base(formatter)
+        {
+            Translator = assemblyTranslator;
+        }
+
+        public override void EmitHeader(bool stubbed, bool iife)
+        {
+            Formatter.WriteRaw(string.Format("module.exports = JSIL.GetAssembly(\"{0}\");", Formatter.Assembly.FullName));
+            Formatter.Semicolon();
+        }
+    }
+
+    public enum Facade {
+        Instance,
+        Type,
+        Static,
+        Factory
+    }
+
+    static class JavascriptFormatterHelper {
+        public enum ReplaceMode {
+            Type,
+            Instance,
+        }
+
+        private static Dictionary<string, string> _rawTypes = new Dictionary<string, string> {
+            {"System.Void", "void"},
+        };
+
+        private static List<string> _coreTypes = new List<string> {
+            "System.String",
+            "System.Byte",
+            "System.SByte",
+            "System.Int16",
+            "System.UInt16",
+            "System.Int32",
+            "System.UInt32",
+            "System.Single",
+            "System.Double",
+            "System.Boolean",
+            "System.Char",
+            "System.Object"
+        };
+
+        private static void TRSuffix (this JavascriptFormatter formatter, ReplaceMode replaceMode) {
+            switch (replaceMode) {
+                case ReplaceMode.Type:
+                    formatter.Dot();
+                    formatter.Identifier("Type");
+                    break;
+                case ReplaceMode.Instance:
+                    formatter.Dot();
+                    formatter.Identifier("Instance");
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException("replaceMode");
+            }
+        }
+
+        public static bool WriteTypeReference (this JavascriptFormatter formatter, TypeReference typeReference, TypeDefinition context, ReplaceMode replaceMode, bool useStandartSubstitution = true) {
+            if (typeReference is ArrayType) {
+                var arrayType = (ArrayType) typeReference;
+                formatter.WriteRaw("$asmJsilCore.System.");
+                formatter.Identifier(arrayType.IsVector ? "Vector" : "Array");
+                formatter.TRSuffix(replaceMode);
+                formatter.WriteRaw("<");
+                formatter.WriteTypeReference(arrayType.ElementType, context, ReplaceMode.Instance);
+                formatter.Comma();
+                formatter.WriteTypeReference(arrayType.ElementType, context, ReplaceMode.Type);
+                if (!arrayType.IsVector) {
+                    formatter.Comma();
+                    formatter.WriteRaw("\"");
+                    formatter.Value(arrayType.Dimensions.Count.ToString(CultureInfo.InvariantCulture));
+                    formatter.WriteRaw("\"");
+                }
+                formatter.WriteRaw(">");
+            } else if (typeReference is ByReferenceType) {
+                var byRefType = (ByReferenceType) typeReference;
+                formatter.WriteRaw("$asmJsilCore.JSIL.Reference");
+                formatter.TRSuffix(replaceMode);
+                formatter.WriteRaw("<");
+                formatter.WriteTypeReference(byRefType.ElementType, context, ReplaceMode.Instance);
+                formatter.Comma();
+                formatter.WriteTypeReference(byRefType.ElementType, context, ReplaceMode.Type);
+                formatter.WriteRaw(">");
+            } else if (typeReference is GenericParameter) {
+                var gp = (GenericParameter) typeReference;
+                DefinitelyTypedUtilities.GenericParemetersKeyedCollection map;
+                if (gp.Owner is TypeDefinition) {
+                    map = DefinitelyTypedUtilities.BuildGenericParemetersMap(((TypeDefinition) gp.Owner).GenericParameters, null);
+                } else if (gp.Owner is MethodDefinition) {
+                    map = DefinitelyTypedUtilities.BuildGenericParemetersMap(((MethodDefinition) gp.Owner).GenericParameters, ((MethodDefinition) gp.Owner).DeclaringType.GenericParameters);
+                } else {
+                    throw new Exception("Unexpected generic parameter owner");
+                }
+
+                var name = map[gp].Value;
+
+                switch (replaceMode) {
+                    case ReplaceMode.Type:
+                        formatter.Identifier(DefinitelyTypedUtilities.GetGenericParameterOutParameterName(name));
+                        break;
+                    case ReplaceMode.Instance:
+                        formatter.Identifier(DefinitelyTypedUtilities.GetGenericParameterInParameterName(name));
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException("replaceMode", replaceMode, null);
+                }
+            } else if (typeReference is GenericInstanceType) {
+                var genericType = (GenericInstanceType) typeReference;
+                if (formatter.WriteTypeReference(genericType.ElementType, context, ReplaceMode.Type)) {
+                    formatter.WriteRaw("<");
+                    formatter.CommaSeparatedList(genericType.GenericArguments, genericArgument => {
+                        formatter.WriteTypeReference(genericArgument, context, ReplaceMode.Instance);
+                        formatter.Comma();
+                        formatter.WriteTypeReference(genericArgument, context, ReplaceMode.Type);
+                    });
+                    formatter.WriteRaw(">");
+                }
+            } else if (typeReference is PointerType || typeReference is OptionalModifierType || typeReference is RequiredModifierType || typeReference is PinnedType || typeReference is SentinelType || typeReference is FunctionPointerType
+                || (!_coreTypes.Contains(typeReference.FullName) && formatter.TypeInfo.Get(typeReference).IsSuppressDeclaration)) {
+                formatter.WriteRaw("Object"); // TODO!
+                return false;
+            } else {
+                string rawType;
+                if (useStandartSubstitution && _rawTypes.TryGetValue(typeReference.FullName, out rawType)) {
+                    formatter.WriteRaw(rawType);
+                } else {
+                    var definition = typeReference.Resolve();
+                    var targetAssembly = JavascriptFormatter.GetContainingAssemblyName(typeReference);
+                    string assemblyRef;
+
+                    if (_coreTypes.Contains(definition.FullName)) {
+                        assemblyRef = "$asmJsilCore";
+                    } else if (targetAssembly == formatter.Assembly.FullName) {
+                        assemblyRef = string.Empty;
+                    } else {
+                        assemblyRef = formatter.Manifest.Entries.FirstOrDefault(item => item.Value == targetAssembly).Key;
+                    }
+                    if (definition != null && assemblyRef != null) {
+                        if (assemblyRef != string.Empty) {
+                            formatter.Identifier(assemblyRef);
+                            formatter.Dot();
+                        } else {
+                            formatter.Identifier("$private");
+                            formatter.Dot();
+                        }
+
+                        foreach (var part in DefinitelyTypedUtilities.GetFullNamespace(definition)) {
+                            formatter.Identifier(part);
+                            formatter.Dot();
+                        }
+
+                        formatter.Identifier(DefinitelyTypedUtilities.GetClassName(definition));
+
+                        /* Hack to solve ciruclar refrence in generics. 
+                         * It could be improved, by we really need generic variance support or support of:
+                         type T = something & I<T>
+                         */
+                        var fixedMode = (replaceMode == ReplaceMode.Type && context == definition) ? ReplaceMode.Instance : replaceMode;
+                        formatter.TRSuffix(fixedMode);
+                    } else {
+                        //TODO: We was unable to resolve assembly. Think about JSIL Proxies
+                        formatter.WriteRaw("Object");
+                        return false;
+                    }
+                }
+            }
+            return true;
+        }
+
+        public static void CommaSeparatedList<T> (this JavascriptFormatter formatter, IEnumerable<T> list, Action<T> process) {
+            bool first = true;
+            foreach (var item in list) {
+                if (first) {
+                    first = false;
+                } else {
+                    formatter.Comma();
+                }
+
+                process(item);
+            }
+        }
+
+        public static void WriteSelfReference (this JavascriptFormatter formatter, TypeDefinition typeDefinition, Facade facade) {
+            switch (facade) {
+                case Facade.Instance:
+                    formatter.Identifier("Instance");
+                    formatter.WriteGenericArgumentsIfNeed(typeDefinition.GenericParameters, null);
+                    break;
+                case Facade.Type:
+                    formatter.Identifier("Type");
+                    formatter.WriteGenericArgumentsIfNeed(typeDefinition.GenericParameters, null);
+                    break;
+                case Facade.Static:
+                    formatter.Identifier("Static");
+                    formatter.WriteGenericArgumentsIfNeed(typeDefinition.GenericParameters, null);
+                    break;
+                case Facade.Factory:
+                    formatter.Identifier("Factory");
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException("facade", facade, null);
+            }
+        }
+
+        public static void WriteGenericMethodSignatureWithoutResultType (this JavascriptFormatter formatter, IEnumerable<GenericParameter> args, IEnumerable<GenericParameter> additionalArgsForNameCalculation) {
+            formatter.WriteGenericArgumentsIfNeed(args, additionalArgsForNameCalculation);
+            formatter.WriteRaw("(");
+
+            formatter.CommaSeparatedList(DefinitelyTypedUtilities.BuildGenericParemetersMap(args, additionalArgsForNameCalculation), pair => {
+                formatter.Identifier("__" + pair.Value);
+                formatter.Space();
+                formatter.WriteRaw(":");
+                formatter.Space();
+                formatter.WriteRaw("$TypePair");
+                formatter.WriteGenericArgumentsIfNeed(new[] {DefinitelyTypedUtilities.GetGenericParameterInParameterName(pair.Value), DefinitelyTypedUtilities.GetGenericParameterOutParameterName(pair.Value)});
+            });
+            formatter.WriteRaw(")");
+        }
+
+        public static void WriteGenericArgumentsIfNeed (this JavascriptFormatter formatter, IEnumerable<GenericParameter> args, IEnumerable<GenericParameter> additionalArgsForNameCalculation) {
+            formatter.WriteGenericArgumentsIfNeed(
+                DefinitelyTypedUtilities.BuildGenericParemetersMap(args, additionalArgsForNameCalculation)
+                    .SelectMany(pair => new[] {DefinitelyTypedUtilities.GetGenericParameterInParameterName(pair.Value), DefinitelyTypedUtilities.GetGenericParameterOutParameterName(pair.Value)}));
+        }
+
+        public static void WriteGenericArgumentsIfNeed (this JavascriptFormatter formatter, IEnumerable<string> genericParameterNames) {
+            var items = genericParameterNames.ToList();
+            if (items.Count > 0) {
+                formatter.WriteRaw("<");
+                formatter.CommaSeparatedList(items, item => { formatter.Identifier(item); });
+                formatter.WriteRaw(">");
+            }
+        }
+
+        public static void EmitInsideNamespace(this JavascriptFormatter formatter, TypeDefinition typedef, bool isTopLevel, Action<bool> inner)
+        {
+            var fullNamespace = DefinitelyTypedUtilities.GetFullNamespace(typedef);
+
+            foreach (var part in fullNamespace)
+            {
+                if (isTopLevel)
+                {
+                    formatter.WriteRaw("export");
+                    formatter.Space();
+                    formatter.WriteRaw("declare");
+                    formatter.Space();
+                    isTopLevel = false;
+                }
+
+                formatter.WriteRaw("namespace");
+                formatter.Space();
+                formatter.Identifier(part);
+                formatter.Space();
+                formatter.OpenBrace();
+            }
+
+            inner(isTopLevel);
+
+            foreach (var part in fullNamespace)
+            {
+                formatter.CloseBrace();
+            }
+        }
+
+    }
+
+    public static class DefinitelyTypedUtilities {
+        public class GenericParemetersKeyedCollection : KeyedCollection<GenericParameter, KeyValuePair<GenericParameter, string>> {
+            protected override GenericParameter GetKeyForItem (KeyValuePair<GenericParameter, string> item) {
+                return item.Key;
+            }
+        }
+
+        public static GenericParemetersKeyedCollection BuildGenericParemetersMap (IEnumerable<GenericParameter> genericParameters, IEnumerable<GenericParameter> useForNameCalculations) {
+            var usedNames = new HashSet<string>();
+            var map = new GenericParemetersKeyedCollection();
+
+            if (useForNameCalculations != null) {
+                foreach (var genericParameter in useForNameCalculations) {
+                    var name = SelectFreeName(genericParameter.Name, usedNames);
+                    usedNames.Add(name);
+                }
+            }
+
+            foreach (var genericParameter in genericParameters) {
+                var name = SelectFreeName(genericParameter.Name, usedNames);
+                usedNames.Add(name);
+                map.Add(new KeyValuePair<GenericParameter, string>(genericParameter, name));
+            }
+            return map;
+        }
+
+        public static IEnumerable<string> GetFullNamespace (TypeDefinition typeReference) {
+            var declaringType = typeReference;
+            while (declaringType.DeclaringType != null) {
+                declaringType = declaringType.DeclaringType;
+            }
+
+            foreach (var part in declaringType.Namespace.Split('.').Where(it => !string.IsNullOrWhiteSpace(it))) {
+                yield return part;
+            }
+        }
+
+        public static string GetClassName (TypeDefinition typeReference) {
+            var declaringType = typeReference;
+            var listOfOuters = new List<string>();
+            do {
+                listOfOuters.Add(declaringType.Name);
+                declaringType = declaringType.DeclaringType;
+            } while (declaringType != null);
+            listOfOuters.Reverse();
+
+            return string.Join("_", listOfOuters);
+        }
+
+        public static string GetGenericParameterInParameterName (string parameterName) {
+            return "__$In_" + parameterName;
+        }
+
+        public static string GetGenericParameterOutParameterName (string parameterName) {
+            return "__$Out_" + parameterName;
+        }
+
+        public static bool IsTypePublic (TypeReference typeReference) {
+            var typeDef = typeReference.Resolve();
+            while (typeDef != null) {
+                if (typeDef.IsPublic) {
+                    return true;
+                }
+                if (!typeDef.IsNestedPublic) {
+                    return false;
+                }
+                typeDef = typeDef.DeclaringType;
+            }
+            return false;
+        }
+
+        private static string SelectFreeName (string original, HashSet<string> usedNames) {
+            var name = original;
+            var i = 1;
+            while (usedNames.Contains(name)) {
+                name = original + "_" + i.ToString(CultureInfo.InvariantCulture);
+            }
+            return name;
+        }
+    }
+
+    public abstract class DefinitelyTypedBaseEmitter : IAssemblyEmitter {
+        public readonly JavascriptFormatter Formatter;
+
+        public DefinitelyTypedBaseEmitter(JavascriptFormatter formatter)
+        {
+            Formatter = formatter;
+        }
+
+        public virtual void EmitHeader (bool stubbed, bool iife) {
+        }
+
+        public virtual void EmitFooter (bool iife) {
+        }
+
+        public virtual void EmitAssemblyEntryPoint (AssemblyDefinition assembly, MethodDefinition entryMethod, MethodSignature signature) {
+        }
+
+        public virtual IAstEmitter MakeAstEmitter(JSILIdentifier jsil, TypeSystem typeSystem, TypeInfoProvider typeInfoProvider, Configuration configuration)
+        {
+            return new DefinitelyTypedEmptyAstEmitter(
+                Formatter, jsil, typeSystem, typeInfoProvider, configuration
+                );
+        }
+
+        public virtual void EmitTypeAlias (TypeDefinition typedef) {
+        }
+
+        public virtual bool EmitTypeDeclarationHeader (DecompilerContext context, IAstEmitter astEmitter, TypeDefinition typedef, TypeInfo typeInfo) {
+            return false;
+        }
+
+        public virtual void EmitCustomAttributes (DecompilerContext context, TypeReference declaringType, ICustomAttributeProvider member, IAstEmitter astEmitter, bool standalone = true) {
+        }
+
+        public virtual void EmitMethodDefinition (DecompilerContext context, MethodReference methodRef, MethodDefinition method, IAstEmitter astEmitter, bool stubbed, JSRawOutputIdentifier dollar, MethodInfo methodInfo = null) {
+        }
+
+        public virtual void EmitSpacer () {
+        }
+
+        public virtual void EmitSemicolon () {
+        }
+
+        public virtual void EmitProxyComment (string fullName) {
+        }
+
+        public virtual void EmitEvent (DecompilerContext context, IAstEmitter astEmitter, EventDefinition @event, JSRawOutputIdentifier dollar) {
+        }
+
+        public virtual void EmitProperty (DecompilerContext context, IAstEmitter astEmitter, PropertyDefinition property, JSRawOutputIdentifier dollar) {
+        }
+
+        public virtual void EmitField (DecompilerContext context, IAstEmitter astEmitter, FieldDefinition field, JSRawOutputIdentifier dollar, JSExpression defaultValue) {
+        }
+
+        public virtual void EmitConstant (DecompilerContext context, IAstEmitter astEmitter, FieldDefinition field, JSRawOutputIdentifier dollar, JSExpression value) {
+        }
+
+        public virtual void EmitPrimitiveDefinition (DecompilerContext context, TypeDefinition typedef, bool stubbed, JSRawOutputIdentifier dollar) {
+        }
+
+        public virtual void BeginEmitTypeDeclaration (TypeDefinition typedef) {
+        }
+
+        public virtual void BeginEmitTypeDefinition (IAstEmitter astEmitter, TypeDefinition typedef, TypeInfo typeInfo, TypeReference baseClass) {
+        }
+
+        public virtual void EndEmitTypeDefinition (IAstEmitter astEmitter, DecompilerContext context, TypeDefinition typedef) {
+        }
+
+        public virtual void EmitInterfaceList (TypeInfo typeInfo, IAstEmitter astEmitter, JSRawOutputIdentifier dollar) {
+        }
+
+        public virtual void EmitCachedValues (IAstEmitter astEmitter, TypeExpressionCacher typeCacher, SignatureCacher signatureCacher, BaseMethodCacher baseMethodCacher) {
+        }
+
+        public virtual void EmitFunctionBody (IAstEmitter astEmitter, MethodDefinition method, JSFunctionExpression function) {
+        }
+
+        public virtual void EmitAssemblyReferences (string assemblyDeclarationReplacement, Dictionary<AssemblyManifest.Token, string> assemblies) {
+        }
+
+        private class DefinitelyTypedEmptyAstEmitter : IAstEmitter
+        {
+
+            public DefinitelyTypedEmptyAstEmitter(
+                JavascriptFormatter output, JSILIdentifier jsil,
+                TypeSystem typeSystem, ITypeInfoSource typeInfo,
+                Configuration configuration
+                )
+            {
+                //Configuration = configuration;
+                //Output = output;
+                //JSIL = jsil;
+                TypeSystem = typeSystem;
+                //TypeInfo = typeInfo;
+
+                //IncludeTypeParens.Push(false);
+                //PassByRefStack.Push(false);
+                //OverflowCheckStack.Push(false);
+
+                //VisitNestedFunctions = true;
+
+                /*if (output.SourceMapBuilder != null)
+                {
+                    BeforeNodeProcessed += AddSourceMapInfo;
+                    //AfterNodeProcessed += AddSourceMapInfoEnd;
+                }*/
+                ReferenceContext = new TypeReferenceContext();
+            }
+
+            public TypeSystem TypeSystem { get; private set; }
+            public TypeReferenceContext ReferenceContext { get; private set; }
+            public SignatureCacher SignatureCacher { get; set; }
+            public void Emit(JSNode node) { }
+        }
+    }
+}

--- a/JSIL/Extensibility/Emitter.cs
+++ b/JSIL/Extensibility/Emitter.cs
@@ -11,23 +11,31 @@ using JSIL.Translator;
 using Mono.Cecil;
 
 namespace JSIL.Compiler.Extensibility {
-    public interface IEmitterFactory {
-        string FileExtension { get; }
-
-        IAssemblyEmitter MakeAssemblyEmitter (
-            AssemblyTranslator assemblyTranslator,
-            AssemblyDefinition assembly,
-            JavascriptFormatter formatter,
-            IDictionary<AssemblyManifest.Token, string> referenceOverrides
-        );
+    public interface IEmitterGroupFactory {
+        IEnumerable<IAssemblyEmmitterFactory> MakeAssemblyEmitterFactory (AssemblyTranslator assemblyTranslator, AssemblyDefinition assembly);
 
         IEnumerable<IAnalyzer> GetAnalyzers ();
+
         Configuration FilterConfiguration (Configuration configuration);
+
+        void RegisterPostprocessor (Action<TranslationResult> action);
+
+        void RunPostprocessors (AssemblyManifest manifest, string assemblyPath, TranslationResult result);
+    }
+
+    public interface IAssemblyEmmitterFactory {
+        string Id { get; }
+
+        string AssemblyPathAndFilename { get; }
+
+        string ArtifactType { get; }
+
+        IAssemblyEmitter MakeAssemblyEmitter (JavascriptFormatter formatter);
     }
 
     public interface IAssemblyEmitter {
-        void EmitHeader (bool stubbed);
-        void EmitFooter ();
+        void EmitHeader (bool stubbed, bool iife);
+        void EmitFooter (bool iife);
         void EmitAssemblyEntryPoint (
             AssemblyDefinition assembly, MethodDefinition entryMethod, MethodSignature signature
         );
@@ -62,6 +70,7 @@ namespace JSIL.Compiler.Extensibility {
         void EmitInterfaceList (TypeInfo typeInfo, IAstEmitter astEmitter, JSRawOutputIdentifier dollar);
         void EmitCachedValues (IAstEmitter astEmitter, TypeExpressionCacher typeCacher, SignatureCacher signatureCacher, BaseMethodCacher baseMethodCacher);
         void EmitFunctionBody (IAstEmitter astEmitter, MethodDefinition method, JSFunctionExpression function);
+        void EmitAssemblyReferences (string assemblyDeclarationReplacement, Dictionary<AssemblyManifest.Token, string> assemblies);
     }
 
     public interface IAstEmitter {

--- a/JSIL/JS Libraries/DefinitelyTyped/internals/JSIL.Core.d.ts
+++ b/JSIL/JS Libraries/DefinitelyTyped/internals/JSIL.Core.d.ts
@@ -11,6 +11,10 @@ export class TypePair<TIn, TOut> extends StaticTypePair<TIn, TOut> {
     /*readonly */$TypedUndefined: TOut;
 }
 
+export class NullArg {
+    private _brand: any;
+}
+
 declare let __jsObject: Object;
 
 export declare namespace $private{

--- a/JSIL/JS Libraries/DefinitelyTyped/internals/JSIL.Core.d.ts
+++ b/JSIL/JS Libraries/DefinitelyTyped/internals/JSIL.Core.d.ts
@@ -1,0 +1,200 @@
+export class StaticTypePair<TIn, TOut> {
+    private _in: TIn;
+    private _out: TOut;
+}
+
+export class TypePair<TIn, TOut> extends StaticTypePair<TIn, TOut> {
+    $Is(input: any): boolean;
+    $As(input: any): TOut;
+    $Cast(input: any): TOut;
+    /*readonly */$TypedUndefinedInternal: TIn;
+    /*readonly */$TypedUndefined: TOut;
+}
+
+declare let __jsObject: Object;
+
+export declare namespace $private{
+    namespace System {
+        namespace Object {
+            class Instance {
+                private _brand: any;
+            }
+            type Type = Instance;
+            interface Static extends TypePair<Instance, Type> {
+                new (): Type
+            }
+            type Factory = Static;
+        }
+        namespace String {
+            type Instance = string;
+            type Type = Instance & Object.Type;
+            interface Static extends TypePair<Instance, Type> {
+                new (arg: string): Type;
+            }
+            type Factory = Static;
+        }
+        namespace Byte {
+            class Instance {
+                private _brand: any;
+            }
+            type Type = Instance & number;
+            interface Static extends TypePair<Instance, Type> {
+                new (arg: number): Type;
+            }
+            type Factory = Static;
+        }
+        namespace SByte {
+            class Instance {
+                private _brand: any;
+            }
+            type Type = Instance & number;
+            interface Static extends TypePair<Instance, Type> {
+                new (arg: number): Type;
+            }
+            type Factory = Static;
+        }
+        namespace Int16 {
+            class Instance {
+                private _brand: any;
+            }
+            type Type = Instance & number;
+            interface Static extends TypePair<Instance, Type> {
+                new (arg: number): Type;
+            }
+            type Factory = Static;
+        }
+        namespace UInt16 {
+            class Instance {
+                private _brand: any;
+            }
+            type Type = Instance & number;
+            interface Static extends TypePair<Instance, Type> {
+                new (arg: number): Type;
+            }
+            type Factory = Static;
+        }
+        namespace Int32 {
+            class Instance {
+                private _brand: any;
+            }
+            type Type = Instance & number;
+            interface Static extends TypePair<Instance, Type> {
+                new (arg: number): Type;
+            }
+            type Factory = Static;
+        }
+        namespace UInt32 {
+            class Instance {
+                private _brand: any;
+            }
+            type Type = Instance & number;
+            interface Static extends TypePair<Instance, Type> {
+                new (arg: number): Type;
+            }
+            type Factory = Static;
+        }
+        namespace Single {
+            type Instance = number
+            type Type = Instance;
+            interface Static extends TypePair<Instance, Type> {
+                new (arg: number): Type;
+            }
+            type Factory = Static;
+        }
+        namespace Double {
+            type Instance = number
+            type Type = Instance;
+            interface Static extends TypePair<Instance, Type> {
+                new (arg: number): Type;
+            }
+            type Factory = Static;
+        }
+        namespace Boolean {
+            type Instance = boolean
+            type Type = Instance;
+            interface Static extends TypePair<Instance, Type> {
+                new (arg: number): Type;
+            }
+            type Factory = Static;
+        }
+        namespace Char {
+            class Instance {
+                private _brand: any;
+            }
+            type Type = Instance & string;
+            interface Static extends TypePair<Instance, Type> {
+                new (arg: number): Type;
+            }
+            type Factory = Static;
+        }
+
+        namespace Array {
+            class Instance<InTType, OutTType, TSize> {
+                private _brand: any;
+                private _TType_brand: OutTType;
+                private _TSize_brand: TSize;
+            }
+            type Type<InTType, OutTType, TSize> = Instance<InTType, OutTType, TSize> & OutTType[];
+            interface Static<InTType, OutTType, TSize> extends TypePair<Instance<InTType, OutTType, TSize>, Type<InTType, OutTType, TSize>> {
+            }
+            interface Factory {
+                Of<InTType, OutTType>(__T: TypePair<InTType, OutTType>): Vector.Static<InTType, OutTType>
+                //Of<InTType, OutTType, TSize>(TType: TypePair<InTType, OutTType>, TSize: TSize): Static<InTType, OutTType, TSize>
+            }
+        }
+
+        namespace Vector {
+            class Instance<InTType, OutTType> {
+                private _brand: any;
+                private _TType_brand: OutTType;
+            }
+            type Type<InTType, OutTType> = Instance<InTType, OutTType> & Array.Type<InTType, OutTType, "1">;
+            interface Static<InTType, OutTType> extends TypePair<Instance<InTType, OutTType>, Type<InTType, OutTType>> {
+            }
+        }
+    }
+
+    namespace JSIL {
+        namespace Reference {
+            interface Instance<InTType, OutTType> {
+                get(): OutTType;
+                set(value: InTType): void;
+            }
+            type Type<InTType, OutTType> = Instance<InTType, OutTType>;
+        }
+
+        namespace BoxedVariable {
+            class Instance<TType> {
+                private _brand: any;
+                private _TType_brand: TType;
+            }
+            type Type<TType> = Instance<TType> & Reference.Type<TType, TType>;
+            interface Factory {
+                new <TType>(arg: TType): Type<TType>
+            }
+        }
+
+        namespace MemberReference {
+            class Instance<TType> {
+                private _brand: any;
+                private _TType_brand: TType;
+            }
+            type Type<TType> = Instance<TType> & Reference.Type<TType, TType>;
+            interface Factory {
+                //TODO: think how to make it static typed
+                new <TType>(object: Object, memberName: string): Type<TType>
+            }
+        }
+
+        namespace ArrayElementReference {
+            class Instance<InTType, OutTType> {
+                private _brand: any;
+                private _TType_brand: InTType;
+            }
+            type Type<InTType, OutTType> = Instance<InTType, OutTType> & Reference.Type<InTType, OutTType>;
+            interface Factory {
+                new <InTType, OutTType>(array: System.Vector.Instance<InTType, OutTType>, index: System.Int32.Instance): Type<InTType, OutTType>
+            }
+        }
+    }
+}

--- a/JSIL/JS Libraries/DefinitelyTyped/module.JSIL.Core.d.ts
+++ b/JSIL/JS Libraries/DefinitelyTyped/module.JSIL.Core.d.ts
@@ -1,0 +1,23 @@
+import {$private as $jsilCore} from "./internals/JSIL.Core";
+
+export declare namespace System {
+    let Object: $jsilCore.System.Object.Factory;
+    let String: $jsilCore.System.String.Factory;
+    let Byte: $jsilCore.System.Byte.Factory;
+    let SByte: $jsilCore.System.SByte.Factory;
+    let Int16: $jsilCore.System.Int16.Factory;
+    let UInt16: $jsilCore.System.UInt16.Factory;
+    let Int32: $jsilCore.System.Int32.Factory;
+    let UInt32: $jsilCore.System.UInt32.Factory;
+    let Single: $jsilCore.System.Single.Factory;
+    let Double: $jsilCore.System.Double.Factory;
+    let Boolean: $jsilCore.System.Boolean.Factory;
+    let Char: $jsilCore.System.Char.Factory;
+    let Array: $jsilCore.System.Array.Factory;
+}
+
+export declare namespace JSIL {
+    let BoxedVariable: $jsilCore.JSIL.BoxedVariable.Factory;
+    let MemberReference: $jsilCore.JSIL.MemberReference.Factory;
+    let ArrayElementReference: $jsilCore.JSIL.ArrayElementReference.Factory;
+}

--- a/JSIL/JS Libraries/DefinitelyTyped/module.JSIL.Core.js
+++ b/JSIL/JS Libraries/DefinitelyTyped/module.JSIL.Core.js
@@ -1,0 +1,1 @@
+module.exports = JSIL.GetAssembly("mscorlib");

--- a/JSIL/JSIL.csproj
+++ b/JSIL/JSIL.csproj
@@ -69,6 +69,7 @@
     <Compile Include="BugChecks.cs" />
     <Compile Include="CILSupport.cs" />
     <Compile Include="Configuration.cs" />
+    <Compile Include="DefinitelyTypedAssemblyEmitter.cs" />
     <Compile Include="Extensibility\Emitter.cs" />
     <Compile Include="Extensibility\IAnalyzer.cs" />
     <Compile Include="FunctionCache.cs" />
@@ -162,43 +163,25 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <None Include="..\Libraries\JSIL.Core.js">
-      <Link>JS Libraries\JSIL.Core.js</Link>
-    </None>
     <None Include="JSIL.dll.config">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>
   <ItemGroup>
-    <None Include="..\Libraries\JSIL.Bootstrap.js">
-      <Link>JS Libraries\JSIL.Bootstrap.js</Link>
-    </None>
-    <None Include="..\Libraries\JSIL.Browser.js">
-      <Link>JS Libraries\JSIL.Browser.js</Link>
-    </None>
-    <None Include="..\Libraries\JSIL.XNA3.js">
-      <Link>JS Libraries\JSIL.XNA3.js</Link>
-    </None>
-    <None Include="..\Libraries\JSIL.XNA4.js">
-      <Link>JS Libraries\JSIL.XNA4.js</Link>
-    </None>
-    <None Include="..\Libraries\System.Drawing.js">
-      <Link>JS Libraries\System.Drawing.js</Link>
-    </None>
-    <None Include="..\Libraries\System.Windows.js">
-      <Link>JS Libraries\System.Windows.js</Link>
-    </None>
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="..\Libraries\JSIL.IO.js">
-      <Link>JS Libraries\JSIL.IO.js</Link>
-    </None>
-  </ItemGroup>
-  <ItemGroup>
-    <Content Include="..\Libraries\JSIL.XNACore.js">
-      <Link>JS Libraries\JSIL.XNACore.js</Link>
-    </Content>
     <Content Include="jsil.ico" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="JS Libraries\DefinitelyTyped\module.JSIL.Core.js">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="JS Libraries\DefinitelyTyped\internals\JSIL.Core.d.ts">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="JS Libraries\DefinitelyTyped\module.JSIL.Core.d.ts">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/JSIL/JavascriptAssemblyEmitter.cs
+++ b/JSIL/JavascriptAssemblyEmitter.cs
@@ -2,8 +2,6 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using ICSharpCode.Decompiler;
 using JSIL.Ast;
 using JSIL.Compiler.Extensibility;
@@ -16,16 +14,13 @@ namespace JSIL {
     class JavascriptAssemblyEmitter : IAssemblyEmitter {
         public readonly AssemblyTranslator  Translator;
         public readonly JavascriptFormatter Formatter;
-        private readonly IDictionary<AssemblyManifest.Token, string> _referenceOverrides;
 
         public JavascriptAssemblyEmitter (
             AssemblyTranslator assemblyTranslator,
-            JavascriptFormatter formatter,
-            IDictionary<AssemblyManifest.Token, string> referenceOverrides
+            JavascriptFormatter formatter
         ) {
             Translator = assemblyTranslator;
             Formatter = formatter;
-            _referenceOverrides = referenceOverrides;
         }
 
         // HACK
@@ -41,7 +36,7 @@ namespace JSIL {
             }
         }
 
-        public void EmitHeader (bool stubbed) {
+        public void EmitHeader (bool stubbed, bool iife) {
             Formatter.Comment(AssemblyTranslator.GetHeaderText());
             Formatter.NewLine();
 
@@ -53,22 +48,26 @@ namespace JSIL {
                 Formatter.NewLine();
             }
 
-            if (_referenceOverrides != null)
+            if (iife)
             {
                 Formatter.LPar();
                 Formatter.OpenFunction(string.Empty, null);
             }
 
-            Formatter.DeclareAssembly();
+        }
+
+        public void EmitAssemblyReferences (string assemblyDeclarationReplacement, Dictionary<AssemblyManifest.Token, string> assemblies) {
+            Formatter.DeclareAssembly(assemblyDeclarationReplacement);
             Formatter.NewLine();
 
-            if (_referenceOverrides != null) {
-                Formatter.WriteReferencesOverrides(_referenceOverrides);
+            if (assemblies != null)
+            {
+                Formatter.WriteReferencesOverrides(assemblies);
             }
         }
 
-        public void EmitFooter () {
-            if (_referenceOverrides != null)
+        public void EmitFooter (bool iife) {
+            if (iife)
             {
                 Formatter.CloseBrace();
                 Formatter.RPar();

--- a/JSIL/JavascriptFormatter.cs
+++ b/JSIL/JavascriptFormatter.cs
@@ -180,7 +180,6 @@ namespace JSIL.Internal {
 
         protected readonly HashSet<string> DeclaredNamespaces = new HashSet<string>();
         protected readonly bool Stubbed;
-        protected readonly string AssemblyDeclarationReplacement;
 
         protected uint _IndentLevel = 0;
         protected bool _IndentNeeded = false;
@@ -196,7 +195,6 @@ namespace JSIL.Internal {
             TextWriter output, SourceMapBuilder sourceMapBuilder, ITypeInfoSource typeInfo, 
             AssemblyManifest manifest, AssemblyDefinition assembly,
             Configuration configuration,
-            string assemblyDeclarationReplacement,
             bool stubbed
         ) {
             if (sourceMapBuilder != null)
@@ -215,17 +213,11 @@ namespace JSIL.Internal {
             Assembly = assembly;
             Configuration = configuration;
             Stubbed = stubbed;
-            AssemblyDeclarationReplacement = assemblyDeclarationReplacement;
 
             PrivateToken = Manifest.GetPrivateToken(assembly);
             Manifest.AssignIdentifiers();
         }
 
-        public bool PreviousWasLineBreak {
-            get {
-                return _IndentNeeded;
-            }
-        }
 
         protected void WriteToken (AssemblyManifest.Token token) {
             if (Stubbed && Configuration.GenerateSkeletonsForStubbedAssemblies.GetValueOrDefault(false)) {
@@ -1162,7 +1154,7 @@ namespace JSIL.Internal {
             RPar();
         }
 
-        public void DeclareAssembly () {
+        public void DeclareAssembly (string assemblyDeclarationReplacement) {
             if (Stubbed && Configuration.GenerateSkeletonsForStubbedAssemblies.GetValueOrDefault(false)) {
                 WriteRaw("var ${0} = new JSIL.AssemblyCollection", Configuration.AssemblyCollectionName ?? "asms");
                 LPar();
@@ -1192,7 +1184,7 @@ namespace JSIL.Internal {
                 Space();
                 Identifier(PrivateToken.IDString);
                 WriteRaw(" = ");
-                if (AssemblyDeclarationReplacement == null)
+                if (string.IsNullOrEmpty(assemblyDeclarationReplacement))
                 {
                     WriteRaw("JSIL.DeclareAssembly");
                     LPar();
@@ -1201,7 +1193,10 @@ namespace JSIL.Internal {
                 }
                 else
                 {
-                    WriteRaw(AssemblyDeclarationReplacement);
+                    WriteRaw("JSIL.GetAssembly");
+                    LPar();
+                    Value(assemblyDeclarationReplacement);
+                    RPar();
                 }
                 Semicolon();
             }
@@ -1215,7 +1210,10 @@ namespace JSIL.Internal {
                 Space();
                 Identifier(reference.Key.IDString);
                 WriteRaw(" = ");
-                WriteRaw(reference.Value);
+                WriteRaw("JSIL.GetAssembly");
+                LPar();
+                Value(reference.Value);
+                RPar();
                 Semicolon();
             }
         }

--- a/Tests/ComparisonTest.cs
+++ b/Tests/ComparisonTest.cs
@@ -450,9 +450,7 @@ namespace JSIL.Tests {
                 try {
                     translationResult = translator.Translate(
                         assemblyPath, scanForProxies == null ? TypeInfo == null : (bool)scanForProxies
-                    );
-
-                    AssemblyTranslator.GenerateManifest(translator.Manifest, assemblyPath, translationResult);
+                    ).TranslationResults[0];
 
                     result = processResult(translationResult);
                 } finally {

--- a/Tests/MetadataTests.cs
+++ b/Tests/MetadataTests.cs
@@ -496,6 +496,8 @@ namespace JSIL.Tests {
                 }, () => {
                     var configuration = MakeConfiguration();
                     configuration.FilenameEscapeRegex = "[^A-Za-z0-9 _]";
+                    // We don't escape manifest
+                    configuration.SkipManifestCreation = true;
                     return configuration;
                 });
 

--- a/Try/SnippetCompiler.cs
+++ b/Try/SnippetCompiler.cs
@@ -277,11 +277,7 @@ namespace JSIL.Try {
                     };
 
                     var translateStarted = DateTime.UtcNow.Ticks;
-                    var translationResult = translator.Translate(resultPath, true);
-
-                    AssemblyTranslator.GenerateManifest(
-                        translator.Manifest, Path.GetDirectoryName(resultPath), translationResult
-                    );
+                    var translationResult = translator.Translate(resultPath, true).TranslationResults[0];
 
                     result.EntryPoint = String.Format(
                         "{0}.{1}",


### PR DESCRIPTION
Initial implementation of TypeScript DefinitelyTyped mappings for translated code.
It is implemented as separate emitter. To enable, jsilconfig should contain: `"EmitterFactories" : ["JavascriptEmitterGroupFactory", "DefinitelyTypedEmitterGroupFactory"]`

When enabled, for each assembly additionally created 3 files:
- `module.%assemblyName%.d.ts`
- `module.%assemblyName%.js`
- `internals\%assemblyName%.d.ts`

And additionally:
- `module.JSIL.Core.d.ts`
- `module.JSIL.Core.js`
- `internals\JSIL.Core.d.ts`

JS file is just a wrapper on top of `JSIL.GetAssembly(...)` in node.js module format.
To use type definition user should reference `module.%assemblyName%`.

What's to do next:
- Introduce test framework and cover with test cases
- Discuss if we need wrap IEmitterGroupFactory[] and IAssemblyEmmitterFactory[] into special types.
- Discuss way to remove values on merge from configuration list/dictionaries
- Better coverage for JSIL.Core.d.ts
- Better interfaces support
- Support generic constraints
- Support of generic interface covariance. Option to enable bivariance for contrvariant generic interfaces.
- Proxied members support.