### PR TITLE
MyGet package publishing

### DIFF
--- a/Compiler/Analyzers/DeadCodeAnalyzer/JSIL.DeadCodeAnalyzer.csproj
+++ b/Compiler/Analyzers/DeadCodeAnalyzer/JSIL.DeadCodeAnalyzer.csproj
@@ -49,6 +49,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\..\..\JSIL\Properties\GlobalAssemblyInfo.cs">
+      <Link>Properties\GlobalAssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="Annotations.cs" />
     <Compile Include="Configuration.cs" />
     <Compile Include="DeadCodeInfoProvider.cs" />

--- a/Compiler/Analyzers/DeadCodeAnalyzer/Properties/AssemblyInfo.cs
+++ b/Compiler/Analyzers/DeadCodeAnalyzer/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -8,10 +7,6 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("Dead code analyzer")]
 [assembly: AssemblyDescription(".NET assembly dead code analyzer for JSIL")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("Dead code analyzer")]
-[assembly: AssemblyCopyright("Copyright ©  2014")]
-[assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
 // Setting ComVisible to false makes the types in this assembly not visible 
@@ -21,15 +16,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("8d203439-f730-4ea9-aff7-a2885947080a")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.1.0.0")]

--- a/Compiler/Compiler.Executor.32bit.csproj
+++ b/Compiler/Compiler.Executor.32bit.csproj
@@ -14,7 +14,7 @@
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <TargetFrameworkProfile />
-    <LangVersion>5</LangVersion>    
+    <LangVersion>5</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugSymbols>true</DebugSymbols>
@@ -37,6 +37,10 @@
     <ApplicationIcon>jsil.ico</ApplicationIcon>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="..\JSIL\Properties\GlobalAssemblyInfo.cs">
+      <Link>Properties\GlobalAssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="Executor.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Compiler/Compiler.csproj
+++ b/Compiler/Compiler.csproj
@@ -63,6 +63,10 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="..\JSIL\Properties\GlobalAssemblyInfo.cs">
+      <Link>Properties\GlobalAssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="..\Upstream\Options.cs" />
     <Compile Include="BuildGroup.cs" />
     <Compile Include="Configuration.cs" />
@@ -75,7 +79,6 @@
     <Compile Include="Profiles\ResourceConverter.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="SolutionBuilder.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="VariableSet.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Compiler/Configuration.cs
+++ b/Compiler/Configuration.cs
@@ -43,6 +43,7 @@ namespace JSIL.Compiler {
         public bool? ReuseTypeInfoAcrossAssemblies;
         public bool? ProxyWarnings;
         public string OutputDirectory;
+        public string JsLibrariesOutputDirectory;
         public string FileOutputDirectory;
         public string Profile;
         public Dictionary<string, object> ProfileSettings = new Dictionary<string, object>();
@@ -66,6 +67,8 @@ namespace JSIL.Compiler {
                 cc.ReuseTypeInfoAcrossAssemblies = ReuseTypeInfoAcrossAssemblies;
             if (OutputDirectory != null)
                 cc.OutputDirectory = OutputDirectory;
+            if (JsLibrariesOutputDirectory != null)
+                cc.JsLibrariesOutputDirectory = JsLibrariesOutputDirectory;
             if (FileOutputDirectory != null)
                 cc.FileOutputDirectory = FileOutputDirectory;
             if (Profile != null)
@@ -108,6 +111,7 @@ namespace JSIL.Compiler {
             result["CurrentDirectory"] = () => Environment.CurrentDirectory;
             result["ConfigDirectory"] = () => Path;
             result["OutputDirectory"] = () => OutputDirectory;
+            result["JsLibrariesOutputDirectory"] = () => JsLibrariesOutputDirectory;
             result["FileOutputDirectory"] = () => FileOutputDirectory;
             result["Profile"] = () => Profile;
 

--- a/Compiler/Extensibility/IProfile.cs
+++ b/Compiler/Extensibility/IProfile.cs
@@ -18,7 +18,7 @@ namespace JSIL.Compiler.Extensibility {
             Configuration configuration, string assemblyPath, bool scanForProxies
         );
         void WriteOutputs (
-            VariableSet variables, TranslationResultCollection result, string path, bool quiet
+            VariableSet variables, TranslationResultCollection result, Configuration path, bool quiet
         );
 
         void RegisterPostprocessors (IEnumerable<IEmitterGroupFactory> emitters, Configuration configuration, string assemblyPath, string[] skippedAssemblies);

--- a/Compiler/Profiles/XNA4/Profiles.XNA4.csproj
+++ b/Compiler/Profiles/XNA4/Profiles.XNA4.csproj
@@ -45,6 +45,9 @@
     <Reference Include="System.XML" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\..\..\JSIL\Properties\GlobalAssemblyInfo.cs">
+      <Link>Properties\GlobalAssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="..\XNACommon.cs" />
     <Compile Include="XNA4Profile.cs" />

--- a/Compiler/Profiles/XNA4/Properties/AssemblyInfo.cs
+++ b/Compiler/Profiles/XNA4/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -8,10 +7,6 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("XNA4")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("XNA4")]
-[assembly: AssemblyCopyright("Copyright ©  2012")]
-[assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
 // Setting ComVisible to false makes the types in this assembly not visible 
@@ -21,16 +16,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("d8124711-3e7f-47ac-a08d-4ab7de555aee")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Compiler/Program.cs
+++ b/Compiler/Program.cs
@@ -188,6 +188,9 @@ namespace JSIL.Compiler {
                     {"o=|out=", 
                         "Specifies the output directory for generated javascript and manifests.",
                         (path) => commandLineConfig.OutputDirectory = Path.GetFullPath(path) },
+                    {"outLibraries=",
+                        "Specifies the output directory for JSIL Libraries.",
+                        (path) => commandLineConfig.JsLibrariesOutputDirectory = Path.GetFullPath(path) },
                     {"q|quiet",
                         "Suppresses non-error/non-warning stderr messages.",
                         (_) => commandLineConfig.Quiet = Quiet = true },
@@ -822,10 +825,16 @@ namespace JSIL.Compiler {
                         if (localConfig.OutputDirectory == null)
                             throw new Exception("No output directory was specified!");
 
-                        var outputDir = MapPath(localConfig.OutputDirectory, localVariables, false);
-                        CopiedOutputGatherer.EnsureDirectoryExists(outputDir);
+                        localConfig.OutputDirectory = MapPath(localConfig.OutputDirectory, localVariables, false);
+                        CopiedOutputGatherer.EnsureDirectoryExists(localConfig.OutputDirectory);
 
-                        InformationWriteLine("// Saving output to '{0}'.", ShortenPath(outputDir) + Path.DirectorySeparatorChar);
+                        InformationWriteLine("// Saving output to '{0}'.", ShortenPath(localConfig.OutputDirectory) + Path.DirectorySeparatorChar);
+
+                        if (!string.IsNullOrEmpty(localConfig.JsLibrariesOutputDirectory))
+                        {
+                            localConfig.JsLibrariesOutputDirectory = MapPath(localConfig.JsLibrariesOutputDirectory, localVariables, false);
+                            CopiedOutputGatherer.EnsureDirectoryExists(localConfig.JsLibrariesOutputDirectory);
+                        }
 
                         // Ensures that the log file contains the name of the profile that was actually used.
                         localConfig.Profile = localProfile.GetType().Name;
@@ -833,9 +842,9 @@ namespace JSIL.Compiler {
                         if (ignoredMethods.Count > 0)
                             Console.Error.WriteLine("// {0} method(s) were ignored during translation. See the log for a list.", ignoredMethods.Count);
 
-                        EmitLog(outputDir, localConfig, filename, outputs, ignoredMethods);
+                        EmitLog(localConfig.OutputDirectory, localConfig, filename, outputs, ignoredMethods);
 
-                        buildGroup.Profile.WriteOutputs(localVariables, outputs, outputDir, Quiet);
+                        buildGroup.Profile.WriteOutputs(localVariables, outputs, localConfig, Quiet);
 
                         totalFailureCount += translator.Failures.Count;
                     }

--- a/Compiler/Properties/AssemblyInfo.cs
+++ b/Compiler/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -8,10 +7,6 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("JSILc")]
 [assembly: AssemblyDescription("JSIL Command Line Compiler")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Squared Interactive")]
-[assembly: AssemblyProduct("JSIL")]
-[assembly: AssemblyCopyright("Copyright © Squared Interactive 2011")]
-[assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
 // Setting ComVisible to false makes the types in this assembly not visible 
@@ -21,15 +16,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("e2342fc2-c01e-470e-8191-fd22b94bb455")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.8.2.*")]

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,4 +1,4 @@
-assembly-versioning-scheme: None
+assembly-versioning-scheme: MajorMinorPatch
 mode: ContinuousDeployment
 next-version: 0.9.1
 branches: {}

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,0 +1,6 @@
+assembly-versioning-scheme: None
+mode: ContinuousDeployment
+next-version: 0.9.1
+branches: {}
+ignore:
+  sha: []

--- a/JSIL.mscorlib/JSIL.mscorlib.csproj
+++ b/JSIL.mscorlib/JSIL.mscorlib.csproj
@@ -41,6 +41,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\JSIL\Properties\GlobalAssemblyInfo.cs">
+      <Link>Properties\GlobalAssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="Imports.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="JSIL\System\NumberFormatter.cs" />

--- a/JSIL.mscorlib/Properties/AssemblyInfo.cs
+++ b/JSIL.mscorlib/Properties/AssemblyInfo.cs
@@ -9,10 +9,6 @@ using JSIL.Meta;
 [assembly: AssemblyTitle("JSIL.mscorlib")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("JSIL.mscorlib")]
-[assembly: AssemblyCopyright("Copyright ©  2015")]
-[assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
 // Setting ComVisible to false makes the types in this assembly not visible 
@@ -23,17 +19,5 @@ using JSIL.Meta;
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("aef2633e-e92c-4a0d-b8e0-a072ed404af7")]
 
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
 [assembly: JSRepaceAssemblyDeclaration("mscorlib")]
 [assembly: JSOverrideAssemblyReference(typeof(object), "mscorlib")]

--- a/JSIL.nuspec
+++ b/JSIL.nuspec
@@ -28,5 +28,7 @@
     <file src="bin\Mono.Cecil.Pdb.dll" target="tools" />
     <file src="bin\JSIL.ExpressionInterpreter.dll" target="tools" />
     <file src="bin\JSIL.ExpressionInterpreter.pdb" target="tools" />
+    <file src="bin\JS Libraries\**" target="tools\JS Libraries" />
+    <file src="Libraries\" target="tools\JS Libraries\JsLibraries" />
   </files>
 </package>

--- a/JSIL.nuspec
+++ b/JSIL.nuspec
@@ -1,0 +1,32 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata>
+    <id>JSIL.Compiler</id>
+    <version>$version$</version>
+    <authors>Squared Interactive</authors>
+    <description>JSIL Command Line Compiler</description>
+    <language>en-US</language>
+    <projectUrl>https://github.com/sq/JSIL</projectUrl>
+    <licenseUrl>https://github.com/sq/JSIL/blob/master/LICENSE</licenseUrl>
+  </metadata>
+  <files>
+    <file src="bin\defaults.jsilconfig" target="tools" />
+    <file src="bin\ICSharpCode.Decompiler.dll" target="tools" />
+    <file src="bin\ICSharpCode.NRefactory.CSharp.dll" target="tools" />
+    <file src="bin\ICSharpCode.NRefactory.dll" target="tools" />
+    <file src="bin\JSIL.dll" target="tools" />
+    <file src="bin\JSIL.Meta.dll" target="tools" />
+    <file src="bin\JSIL.Proxies.4.0.dll" target="tools" />
+    <file src="bin\JSIL.Proxies.Bcl.dll" target="tools" />
+    <file src="bin\JSILc.exe" target="tools" />
+    <file src="bin\JSILc.exe.config" target="tools" />
+    <file src="bin\JSILc.AnyCPU.exe" target="tools" />
+    <file src="bin\JSILc.AnyCPU.exe.config" target="tools" />    
+    <file src="bin\JSIL.Analysis.DCE.dll" target="tools" />
+    <file src="bin\Mono.Cecil.dll" target="tools" />
+    <file src="bin\Mono.Cecil.Mdb.dll" target="tools" />
+    <file src="bin\Mono.Cecil.Pdb.dll" target="tools" />
+    <file src="bin\JSIL.ExpressionInterpreter.dll" target="tools" />
+    <file src="bin\JSIL.ExpressionInterpreter.pdb" target="tools" />
+  </files>
+</package>

--- a/JSIL/JSIL.csproj
+++ b/JSIL/JSIL.csproj
@@ -85,6 +85,7 @@
     <Compile Include="PackedStructArray.cs" />
     <Compile Include="Progress.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Properties\GlobalAssemblyInfo.cs" />
     <Compile Include="SourceMapBuilder.cs" />
     <Compile Include="SpecialIdentifiers.cs" />
     <Compile Include="Threading.cs" />

--- a/JSIL/Properties/AssemblyInfo.cs
+++ b/JSIL/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -8,10 +7,6 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("JSIL")]
 [assembly: AssemblyDescription("MSIL to Javascript Translator Library")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Squared Interactive")]
-[assembly: AssemblyProduct("JSIL")]
-[assembly: AssemblyCopyright("Copyright © Squared Interactive 2011")]
-[assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
 // Setting ComVisible to false makes the types in this assembly not visible 
@@ -21,15 +16,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("ab70f926-4c13-4da0-926c-05642b4857a7")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.8.2.*")]

--- a/JSIL/Properties/GlobalAssemblyInfo.cs
+++ b/JSIL/Properties/GlobalAssemblyInfo.cs
@@ -1,0 +1,13 @@
+﻿using System.Reflection;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyCompany("Squared Interactive")]
+[assembly: AssemblyProduct("JSIL")]
+[assembly: AssemblyCopyright("Copyright © Squared Interactive 2011")]
+[assembly: AssemblyTrademark("")]
+
+[assembly: AssemblyVersion("0.9.0.0")]
+[assembly: AssemblyInformationalVersion("0.9.0-local")]
+[assembly: AssemblyFileVersion("0.9.0.0")]

--- a/MsBuild/JSIL.MsBuild.nuspec
+++ b/MsBuild/JSIL.MsBuild.nuspec
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata>
+    <id>JSIL.MsBuild</id>
+    <version>$version$</version>
+    <authors>Squared Interactive</authors>
+    <description>JSIL MsBuild Integration</description>
+    <language>en-US</language>
+    <projectUrl>https://github.com/sq/JSIL</projectUrl>
+    <licenseUrl>https://github.com/sq/JSIL/blob/master/LICENSE</licenseUrl>
+    <dependencies>
+      <dependency id="JSIL.Compiler" version="[$version$]" />
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="JSIL.targets" target="build" />
+  </files>
+</package>

--- a/MsBuild/JSIL.MsBuild.nuspec
+++ b/MsBuild/JSIL.MsBuild.nuspec
@@ -13,6 +13,6 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="JSIL.targets" target="build" />
+    <file src="JSIL.MsBuild.targets" target="build" />
   </files>
 </package>

--- a/MsBuild/JSIL.MsBuild.targets
+++ b/MsBuild/JSIL.MsBuild.targets
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <Target Name="JsilTranslation" AfterTargets="AfterBuild">
+        <Exec Command="$(MSBuildThisFileDirectory)..\..\JSIL.Compiler.%VERSION%\tools\jsilc &quot;$(TargetPath)&quot;" WorkingDirectory="$(TargetDir)" />
+    </Target>
+</Project>

--- a/MsBuild/JSIL.targets
+++ b/MsBuild/JSIL.targets
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <Target Name="JsilTranslation" AfterTarget="AfterBuild">
-        <Exec Command="$(MSBuildThisFileDirectory)..\..\JSIL.Compiler.$VERSION$\tools\jsilc &quot;$(TargetPath)&quot;" WorkingDirectory="$(TargetDir)" />
-    </Target>
-</Project>

--- a/MsBuild/JSIL.targets
+++ b/MsBuild/JSIL.targets
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <Target Name="JsilTranslation" AfterTarget="AfterBuild">
+        <Exec Command="$(MSBuildThisFileDirectory)..\..\JSIL.Compiler.$VERSION$\tools\jsilc &quot;$(TargetPath)&quot;" WorkingDirectory="$(TargetDir)" />
+    </Target>
+</Project>

--- a/Proxies/BCL/Properties/AssemblyInfo.cs
+++ b/Proxies/BCL/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -8,10 +7,6 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("JSIL Proxies BLC")]
 [assembly: AssemblyDescription("JSIL Standard Type Proxies for BCL assemblies")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Squared Interactive")]
-[assembly: AssemblyProduct("JSIL")]
-[assembly: AssemblyCopyright("Copyright © Squared Interactive 2011")]
-[assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
 // Setting ComVisible to false makes the types in this assembly not visible 
@@ -21,16 +16,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("8BB79C50-0821-4C59-AFF8-21F25591F0E4")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Proxies/BCL/Proxies.Bcl.csproj
+++ b/Proxies/BCL/Proxies.Bcl.csproj
@@ -36,6 +36,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\..\JSIL\Properties\GlobalAssemblyInfo.cs">
+      <Link>Properties\GlobalAssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="JSIL.Async.cs" />
     <Compile Include="JSIL.Bootstrap.cs" />
     <Compile Include="JSIL.Bootstrap.DateTime.cs" />

--- a/Proxies/Properties/AssemblyInfo.cs
+++ b/Proxies/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -8,10 +7,6 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("JSIL Proxies")]
 [assembly: AssemblyDescription("JSIL Standard Type Proxies")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Squared Interactive")]
-[assembly: AssemblyProduct("JSIL")]
-[assembly: AssemblyCopyright("Copyright © Squared Interactive 2011")]
-[assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
 // Setting ComVisible to false makes the types in this assembly not visible 
@@ -21,16 +16,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("28ac4af1-39f8-41f5-9d58-83b0b906156f")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Proxies/Proxies.4.0.csproj
+++ b/Proxies/Proxies.4.0.csproj
@@ -35,6 +35,9 @@
     <Reference Include="System" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\JSIL\Properties\GlobalAssemblyInfo.cs">
+      <Link>Properties\GlobalAssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="Array.cs" />
     <Compile Include="Console.cs" />
     <Compile Include="Collections.cs" />

--- a/Proxies/XNA4/Properties/AssemblyInfo.cs
+++ b/Proxies/XNA4/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -8,10 +7,6 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("JSIL Proxies")]
 [assembly: AssemblyDescription("JSIL XNA Type Proxies")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Squared Interactive")]
-[assembly: AssemblyProduct("JSIL")]
-[assembly: AssemblyCopyright("Copyright © Squared Interactive 2011")]
-[assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
 // Setting ComVisible to false makes the types in this assembly not visible 
@@ -21,16 +16,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("e5eb9c65-1323-4620-bae8-c856b9df3a99")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Proxies/XNA4/Proxies.XNA4.csproj
+++ b/Proxies/XNA4/Proxies.XNA4.csproj
@@ -45,6 +45,9 @@
     <Reference Include="System.Core" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\..\JSIL\Properties\GlobalAssemblyInfo.cs">
+      <Link>Properties\GlobalAssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="..\XNACommon\Primitives.cs" />
     <Compile Include="..\XNACommon\UnsafeNativeMethods.cs" />
     <Compile Include="..\XNACommon\Content.cs" />

--- a/Tests.DCE/Properties/AssemblyInfo.cs
+++ b/Tests.DCE/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -8,10 +7,6 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("Tests.DCE")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("Tests.DCE")]
-[assembly: AssemblyCopyright("Copyright ©  2015")]
-[assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
 // Setting ComVisible to false makes the types in this assembly not visible 
@@ -21,16 +16,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("940a7fc1-3cff-43cf-bac7-a27ab18cd0b1")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Tests.DCE/Tests.DCE.csproj
+++ b/Tests.DCE/Tests.DCE.csproj
@@ -76,6 +76,9 @@
     <None Include="DCETests\DCEMetaAttributesOnProxies.cs" />
     <None Include="DCETests\StripOuterTypes.cs" />
     <None Include="DCETests\StripInterfaceImplementation.cs" />
+    <Compile Include="..\JSIL\Properties\GlobalAssemblyInfo.cs">
+      <Link>GlobalAssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="DeadCodeEliminationTest.cs" />
     <None Include="app.config" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/Tests.DCE/Tests.DCE.csproj
+++ b/Tests.DCE/Tests.DCE.csproj
@@ -77,7 +77,7 @@
     <None Include="DCETests\StripOuterTypes.cs" />
     <None Include="DCETests\StripInterfaceImplementation.cs" />
     <Compile Include="..\JSIL\Properties\GlobalAssemblyInfo.cs">
-      <Link>GlobalAssemblyInfo.cs</Link>
+      <Link>Properties\GlobalAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="DeadCodeEliminationTest.cs" />
     <None Include="app.config" />

--- a/Tests/Properties/AssemblyInfo.cs
+++ b/Tests/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -8,10 +7,6 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("Tests")]
 [assembly: AssemblyDescription("JSIL Test Suite")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Squared Interactive")]
-[assembly: AssemblyProduct("JSIL")]
-[assembly: AssemblyCopyright("Copyright © Squared Interactive 2011")]
-[assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
 // Setting ComVisible to false makes the types in this assembly not visible 
@@ -21,16 +16,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("ca7c359b-0f27-40c7-ba51-7220a6c69e65")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Tests/SimpleTests.csproj
+++ b/Tests/SimpleTests.csproj
@@ -110,6 +110,9 @@
     <None Include="SimpleTestCases\RawTypeIsObject_Issue754.cs" />
     <None Include="SimpleTestCases\HashSetSameHash_Issue752.cs" />
     <None Include="SimpleTestCases\ArrayClearGeneric.cs" />
+    <Compile Include="..\JSIL\Properties\GlobalAssemblyInfo.cs">
+      <Link>Properties\GlobalAssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="SimpleTestCasesForStubbedBcl.cs" />
     <None Include="SimpleTestCasesForTranslatedBcl\FailsOnMono\Attributes.cs" />
     <Compile Include="SimpleTestCasesForTranslatedBcl.cs" />

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -161,6 +161,9 @@
     <None Include="EmscriptenTestCases\OutUnionParameter.cs" />
     <None Include="EmscriptenTestCases\OutComplexUnionParameter.cs" />
     <None Include="EmscriptenTestCases\ReturnEnum.cs" />
+    <Compile Include="..\JSIL\Properties\GlobalAssemblyInfo.cs">
+      <Link>Properties\GlobalAssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="EmscriptenTestCases\ProxiedExternFunction.cs" />
     <None Include="EmscriptenTestCases\IntPtrZeroEquality.cs" />
     <None Include="EmscriptenTestCases\StringArrayParameter.cs" />

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,9 @@ install:
 build_script:
   - msbuild "JSIL.sln" /m /verbosity:minimal /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" /P:Platform=NoXNA
 after_build:
+  - ps: (gc MsBuild\JSIL.targets) -replace '$VERSION$', $Env:GitVersion_NuGetVersion | Out-File MsBuild\JSIL.targets
   - cmd: nuget pack JSIL.nuspec -version "%GitVersion_NuGetVersion%"
+  - cmd: nuget pack MsBuild\JSIL.MsBuild.nuspec -version "%GitVersion_NuGetVersion%"
 test_script:
   - nunit-console-x86 bin\Tests.DCE.dll bin\SimpleTests.dll bin\Tests.dll /include:"FailsOnMono|(FailsOnMonoWhenStubbed+Stubbed)|(FailsOnMonoWhenStubbed+Translated)"
 artifacts:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,6 @@ install:
   - ps: gitversion /l console /output buildserver /updateAssemblyInfo JSIL\Properties\GlobalAssemblyInfo.cs
 build_script:
   - msbuild "JSIL.sln" /m /verbosity:minimal /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" /P:Platform=NoXNA
-  - NuGet pack JSIL.nuspec -Version %JsilVersion%
 after_build:
   - cmd: nuget pack JSIL.nuspec -version "%GitVersion_NuGetVersion%"
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ install:
   - git submodule update --init --recursive
   - nuget restore JSIL.sln
   - choco install gitversion.portable -pre -y
-  - ps: gitversion /l console /output buildserver /updateAssemblyInfo
+  - ps: gitversion /l console /output buildserver /updateAssemblyInfo JSIL\Properties\GlobalAssemblyInfo.cs
 build_script:
   - msbuild "JSIL.sln" /m /verbosity:minimal /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" /P:Platform=NoXNA
   - NuGet pack JSIL.nuspec -Version %JsilVersion%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,18 @@ cache:
 install:
   - git submodule update --init --recursive
   - nuget restore JSIL.sln
+  - choco install gitversion.portable
+  - GitVersion /output json /showvariable NuGetVersionV2 > version.log
+  - set /p JsilVersion= < version.log
 build_script:
   - msbuild "JSIL.sln" /m /verbosity:minimal /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" /P:Platform=NoXNA
+  - NuGet pack JSIL.nuspec -Version %JsilVersion%
 test_script:
   - nunit-console-x86 bin\Tests.DCE.dll bin\SimpleTests.dll bin\Tests.dll /include:"FailsOnMono|(FailsOnMonoWhenStubbed+Stubbed)|(FailsOnMonoWhenStubbed+Translated)"
+deploy:
+  provider: NuGet
+  server: https://www.myget.org/F/iskiselev/api/v2/package
+  api_key:
+    secure: WErGDvZpSSAr+nQs6+5K8wKAQkS7YKb56T8sJ7gCI85Rh8dlEnE6CiMQ5SyUjE69
+  skip_symbols: true
+  artifact: /.*\.nupkg/

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,8 +19,8 @@ artifacts:
   - path: '*.nupkg' 
 deploy:
   provider: NuGet
-  server: https://www.myget.org/F/iskiselev/api/v2/package
+  server: https://www.myget.org/F/jsil/api/v2/package
   api_key:
-    secure: WErGDvZpSSAr+nQs6+5K8wKAQkS7YKb56T8sJ7gCI85Rh8dlEnE6CiMQ5SyUjE69
+    secure: EBvntnmrV7ni1xQY8grb2sUAOeMlNqGkkqRSdMJrLPG5N42YRCxhZ7DT5Nor/l6k
   skip_symbols: true
   artifact: /.*\.nupkg/

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,6 +13,8 @@ build_script:
   - NuGet pack JSIL.nuspec -Version %JsilVersion%
 test_script:
   - nunit-console-x86 bin\Tests.DCE.dll bin\SimpleTests.dll bin\Tests.dll /include:"FailsOnMono|(FailsOnMonoWhenStubbed+Stubbed)|(FailsOnMonoWhenStubbed+Translated)"
+artifacts:
+  - path: '*.nupkg' 
 deploy:
   provider: NuGet
   server: https://www.myget.org/F/iskiselev/api/v2/package

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,7 @@ install:
 build_script:
   - msbuild "JSIL.sln" /m /verbosity:minimal /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" /P:Platform=NoXNA
 after_build:
-  - ps: (gc MsBuild\JSIL.MsBuild.targets) -replace '%VERSION%', $Env:GitVersion_NuGetVersion | Out-File MsBuild\JSIL.MsBuild.targets
+  - ps: (gc MsBuild\JSIL.MsBuild.targets) -replace '%VERSION%', $Env:GitVersion_NuGetVersion | Out-File -Encoding "UTF8" MsBuild\JSIL.MsBuild.targets
   - cmd: nuget pack JSIL.nuspec -version "%GitVersion_NuGetVersion%"
   - cmd: nuget pack MsBuild\JSIL.MsBuild.nuspec -version "%GitVersion_NuGetVersion%"
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,12 +5,13 @@ cache:
 install:
   - git submodule update --init --recursive
   - nuget restore JSIL.sln
-  - choco install gitversion.portable
-  - GitVersion /output json /showvariable NuGetVersionV2 > version.log
-  - set /p JsilVersion= < version.log
+  - choco install gitversion.portable -pre -y
+  - ps: gitversion /l console /output buildserver /updateAssemblyInfo
 build_script:
   - msbuild "JSIL.sln" /m /verbosity:minimal /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" /P:Platform=NoXNA
   - NuGet pack JSIL.nuspec -Version %JsilVersion%
+after_build:
+  - cmd: nuget pack JSIL.nuspec -version "%GitVersion_NuGetVersion%"
 test_script:
   - nunit-console-x86 bin\Tests.DCE.dll bin\SimpleTests.dll bin\Tests.dll /include:"FailsOnMono|(FailsOnMonoWhenStubbed+Stubbed)|(FailsOnMonoWhenStubbed+Translated)"
 artifacts:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,7 @@ install:
 build_script:
   - msbuild "JSIL.sln" /m /verbosity:minimal /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" /P:Platform=NoXNA
 after_build:
-  - ps: (gc MsBuild\JSIL.targets) -replace '$VERSION$', $Env:GitVersion_NuGetVersion | Out-File MsBuild\JSIL.targets
+  - ps: (gc MsBuild\JSIL.MsBuild.targets) -replace '%VERSION%', $Env:GitVersion_NuGetVersion | Out-File MsBuild\JSIL.MsBuild.targets
   - cmd: nuget pack JSIL.nuspec -version "%GitVersion_NuGetVersion%"
   - cmd: nuget pack MsBuild\JSIL.MsBuild.nuspec -version "%GitVersion_NuGetVersion%"
 test_script:


### PR DESCRIPTION
Implemented publishing JSIL package to MyGet feed. Use [GitVersion](http://gitversion.readthedocs.io/en/latest/) for versioning, bumped version to 0.9.1 for now.
JSILc from nuget package now able to copy Libraries to designed folder (use settings JsLibrariesOutputDirectory in jsilconfig or outLibraries command line parameter).

Current version of package doesn't contains any XNA translation related assemblies. I have no plans to integrate them for now (but it could be done by somebody else).