### PR TITLE
DCE assembly white list

### DIFF
--- a/Compiler/Analyzers/DeadCodeAnalyzer/Configuration.cs
+++ b/Compiler/Analyzers/DeadCodeAnalyzer/Configuration.cs
@@ -9,7 +9,8 @@ namespace JSIL.Compiler.Extensibility.DeadCodeAnalyzer {
         private readonly bool _DeadCodeElimination;
         private readonly bool _NonAggressiveVirtualMethodElimination;
         private readonly IList<string> _WhiteList;
-  
+        private readonly IList<string> _AssembliesWhiteList;
+
         public Configuration(IDictionary<string, object> configuration) {
             _DeadCodeElimination = configuration.ContainsKey("DeadCodeElimination") &&
                                   configuration["DeadCodeElimination"] is bool &&
@@ -22,6 +23,11 @@ namespace JSIL.Compiler.Extensibility.DeadCodeAnalyzer {
             if (configuration.ContainsKey("WhiteList") &&
                 configuration["WhiteList"] is IList) {
                 _WhiteList = ((IList) configuration["WhiteList"]).Cast<string>().ToList();
+            }
+
+            if (configuration.ContainsKey("AssembliesWhiteList") && configuration["AssembliesWhiteList"] is IList)
+            {
+                _AssembliesWhiteList = ((IList)configuration["AssembliesWhiteList"]).Cast<string>().ToList();
             }
         }
 
@@ -38,6 +44,11 @@ namespace JSIL.Compiler.Extensibility.DeadCodeAnalyzer {
         public IList<string> WhiteList
         {
             get { return _WhiteList; }
+        }
+
+        public IList<string> AssembliesWhiteList
+        {
+            get { return _AssembliesWhiteList; }
         }
     }
 }

--- a/Compiler/Analyzers/DeadCodeAnalyzer/DeadCodeInfoProvider.cs
+++ b/Compiler/Analyzers/DeadCodeAnalyzer/DeadCodeInfoProvider.cs
@@ -117,6 +117,7 @@ namespace JSIL.Compiler.Extensibility.DeadCodeAnalyzer {
         private readonly HashSet<EventDefinition> Events = new HashSet<EventDefinition>();
 
         private readonly TypeMapStep TypeMapStep = new TypeMapStep();
+        private readonly List<Regex> AssembliesWhiteListCache;
         private readonly List<Regex> WhiteListCache;
         private readonly Configuration Configuration; 
 
@@ -128,6 +129,16 @@ namespace JSIL.Compiler.Extensibility.DeadCodeAnalyzer {
                 foreach (var pattern in configuration.WhiteList) {
                     var compiledRegex = new Regex(pattern, RegexOptions.ECMAScript | RegexOptions.Compiled);
                     WhiteListCache.Add(compiledRegex);
+                }
+            }
+
+            if (configuration.AssembliesWhiteList != null && configuration.AssembliesWhiteList.Count > 0)
+            {
+                AssembliesWhiteListCache = new List<Regex>(configuration.AssembliesWhiteList.Count);
+                foreach (var pattern in configuration.AssembliesWhiteList)
+                {
+                    var compiledRegex = new Regex(pattern, RegexOptions.ECMAScript | RegexOptions.Compiled);
+                    AssembliesWhiteListCache.Add(compiledRegex);
                 }
             }
         }
@@ -892,6 +903,14 @@ namespace JSIL.Compiler.Extensibility.DeadCodeAnalyzer {
 
         private bool IsMemberWhiteListed(MemberReference member)
         {
+            if (AssembliesWhiteListCache != null)
+            {
+                if (AssembliesWhiteListCache.Any(regex => regex.IsMatch(member.Module.Assembly.FullName)))
+                {
+                    return true;
+                }
+            }
+
             if (WhiteListCache != null) {
                 if (WhiteListCache.Any(regex => regex.IsMatch(member.FullName))) {
                     return true;


### PR DESCRIPTION
Added configuration ("AssembliesWhiteList"), that allow white-list all members from some assemblies.