### PR TITLE
TypeInfo Api

### DIFF
--- a/JSIL.Libraries/Includes/Core/Reflection/Classes/System.Reflection.IntrospectionExtensions.js
+++ b/JSIL.Libraries/Includes/Core/Reflection/Classes/System.Reflection.IntrospectionExtensions.js
@@ -8,3 +8,6 @@
     );
   }
 );
+
+JSIL.MakeStaticClass("System.Reflection.IntrospectionExtensions", true, [], function ($) {
+});

--- a/JSIL.Libraries/Includes/Core/Reflection/Classes/System.Type.js
+++ b/JSIL.Libraries/Includes/Core/Reflection/Classes/System.Type.js
@@ -71,6 +71,13 @@
       }
     );
 
+    $.Method({ Static: false, Public: true }, "get_GenericTypeArguments",
+        (new JSIL.MethodSignature($jsilcore.TypeRef("System.Array", [$.Type]), [], [])),
+        function GetGenericArguments() {
+            return this.GetGenericArguments();
+        }
+    );
+
     $.Method({ Static: false, Public: true }, "MakeGenericType",
       (new JSIL.MethodSignature($.Type, [$jsilcore.TypeRef("System.Array", [$.Type])], [])),
       function (typeArguments) {
@@ -401,6 +408,13 @@
           this, flags | System.Reflection.BindingFlags.DeclaredOnly, "ConstructorInfo", null, false, $jsilcore.System.Array.Of($jsilcore.System.Reflection.ConstructorInfo).__Type__
         );
       }
+    );
+
+    $.Method({ Static: false, Public: true }, "get_DeclaredConstructors",
+        new JSIL.MethodSignature($jsilcore.TypeRef("System.Collections.Generic.IEnumerable`1", [$jsilcore.TypeRef("System.Reflection.ConstructorInfo")]), []),
+        function () {
+            return this.GetConstructors();
+        }
     );
 
     $.Method({ Public: true, Static: false }, "GetFields",

--- a/JSIL.Libraries/Sources/JSIL.Core.js
+++ b/JSIL.Libraries/Sources/JSIL.Core.js
@@ -7539,7 +7539,7 @@ JSIL.MethodSignature.prototype.toString = function (name, includeReturnType) {
   } else if (this.returnType !== null) {
     signature = JSIL.TypeReferenceToName(this.returnType) + " ";
   } else {
-    signature = "void ";
+    signature = "Void ";
   }
 
   if (typeof (name) === "string") {

--- a/Proxies/BCL/JSIL.Core.Reflection.cs
+++ b/Proxies/BCL/JSIL.Core.Reflection.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using JSIL.Meta;
 using JSIL.Proxy;
 
@@ -14,5 +15,16 @@ namespace JSIL.Proxies.Bcl
     [JSStubOnly]
     public class System_Reflection_EventInfo
     {
+    }
+
+    [JSProxy("System.Reflection.IntrospectionExtensions", JSProxyMemberPolicy.ReplaceNone, JSProxyAttributePolicy.ReplaceDeclared, JSProxyInterfacePolicy.ReplaceNone, false)]
+    [JSStubOnly]
+    public class System_Reflection_IntrospectionExtensions
+    {
+        [JSExternal]
+        public static AnyType /* System.Reflection.TypeInfo */ GetTypeInfo(Type type)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/Tests/MetadataTests.cs
+++ b/Tests/MetadataTests.cs
@@ -187,7 +187,7 @@ namespace JSIL.Tests {
             var generatedJs = GenericIgnoreTest(
                 @"SpecialTestCases\StubbedMethodBodies.cs",
                 "",
-                "The external method 'void Main(System.String[])' of type 'Program'",
+                "The external method 'Void Main(System.String[])' of type 'Program'",
                 new [] { ".*" }
             );
 
@@ -330,7 +330,7 @@ namespace JSIL.Tests {
         public void ExternalMethod () {
             var generatedJs = GenericIgnoreTest(
                 @"SpecialTestCases\ExternalMethod.cs",
-                "Method", "external method 'void Method()' of type 'Program' has not"
+                "Method", "external method 'Void Method()' of type 'Program' has not"
             );
 
             Assert.IsTrue(generatedJs.Contains("$thisType.Method("));
@@ -541,7 +541,7 @@ namespace JSIL.Tests {
             var generatedJs = GenericIgnoreTest(
                 @"SpecialTestCases\TranslateTypeInStubbedAssembly.cs",
                 "",
-                "method 'void Main(System.String[])' of type 'Program'",
+                "method 'Void Main(System.String[])' of type 'Program'",
                 new[] { ".*" }
             );
 
@@ -563,7 +563,7 @@ namespace JSIL.Tests {
             var generatedJs = GenericIgnoreTest(
                 @"SpecialTestCases\TranslateMethodInStubbedAssembly.cs",
                 expectedOutput,
-                "method 'void Main(System.String[])' of type 'Program'",
+                "method 'Void Main(System.String[])' of type 'Program'",
                 new[] { ".*" }
             );
 

--- a/Tests/SimpleTestCases/TypeInfoApi.cs
+++ b/Tests/SimpleTestCases/TypeInfoApi.cs
@@ -1,0 +1,11 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+public static class Program {
+    public static void Main (string[] args) {
+        Console.WriteLine(IntrospectionExtensions.GetTypeInfo(typeof(Exception)).DeclaredConstructors.First(obj => obj.GetParameters().Length == 2));
+        Console.WriteLine(typeof(List<int>).GetTypeInfo().GenericTypeArguments[0] == typeof(int) ? "true" : "false");
+    }
+}

--- a/Tests/SimpleTestCases/TypeInfoApi.cs
+++ b/Tests/SimpleTestCases/TypeInfoApi.cs
@@ -4,8 +4,19 @@ using System.Linq;
 using System.Reflection;
 
 public static class Program {
-    public static void Main (string[] args) {
-        Console.WriteLine(IntrospectionExtensions.GetTypeInfo(typeof(Exception)).DeclaredConstructors.First(obj => obj.GetParameters().Length == 2));
+    public static void Main (string[] args)
+    {
+        var assertion = IntrospectionExtensions.GetTypeInfo(typeof(Exception)).DeclaredConstructors
+            .Any(obj => obj.GetParameters().Length == 2
+                        && obj.GetParameters()[0].ParameterType == typeof(string)
+                        && obj.GetParameters()[1].ParameterType == typeof(Exception));
+        if (!assertion)
+        {
+            throw new Exception("Invalid result for DeclaredConstructors");
+        }
+
+        Console.WriteLine(assertion ? "true" : "false");
+
         Console.WriteLine(typeof(List<int>).GetTypeInfo().GenericTypeArguments[0] == typeof(int) ? "true" : "false");
     }
 }

--- a/Tests/SimpleTests.csproj
+++ b/Tests/SimpleTests.csproj
@@ -147,6 +147,7 @@
     <None Include="SimpleTestCasesForTranslatedBcl\Issue1008_MethodReturnType.cs" />
     <None Include="SimpleTestCases\GetTypeFromAssembly_Issue1035.cs" />
     <None Include="SimpleTestCases\AsyncAwaitCancel.cs" />
+    <None Include="SimpleTestCases\TypeInfoApi.cs" />
     <Compile Include="SimpleTests.cs" />
     <None Include="SimpleTestCases\BaseAutoProperties.cs" />
     <None Include="SimpleTestCases\OverloadedVirtualMethods.cs" />


### PR DESCRIPTION
Added IEnumerable<System.Reflection.ConstructorInfo> TypeInfo.DeclaredConstructors { get; }
Added Type[] Type.GenericTypeArguments { get; }
Fixed System.Reflection.IntrospectionExtensions for ignored BCL.

Updated toString of Void signature