### PR TITLE
Implement Enumerable.Repeat

### DIFF
--- a/JSIL.Libraries/Includes/Bootstrap/Linq/Classes/System.Linq.Enumerable.js
+++ b/JSIL.Libraries/Includes/Bootstrap/Linq/Classes/System.Linq.Enumerable.js
@@ -557,6 +557,32 @@
         }
       );
 
+      $.Method({ Static: true, Public: true }, "Repeat",
+        new JSIL.MethodSignature(
+          $jsilcore.TypeRef("System.Collections.Generic.IEnumerable`1", ["!!0"]),
+          ["!!0", "System.Int32"],
+          ["TResult"]),
+        function Repeat$b1(TResult, element, count) {
+            var i = 0;
+
+            return new (JSIL.AbstractEnumerable.Of(TResult))(
+              function getNext(result) {
+                  if (i < count) {
+                      i++;
+                      result.set(element);
+                      return true;
+                  }
+                  return false;
+              },
+              function reset() {
+                  i = 0;
+              },
+              function dispose() {
+              }
+            );
+        }
+      );
+
       $.Method({ Static: true, Public: true }, "Where",
         new JSIL.MethodSignature($jsilcore.TypeRef("System.Collections.Generic.IEnumerable`1", ["!!0"]), [$jsilcore.TypeRef("System.Collections.Generic.IEnumerable`1", ["!!0"]), $jsilcore.TypeRef("System.Func`2", ["!!0", $.Boolean])], ["TSource"]),
         function Where$b1(TSource, source, predicate) {

--- a/Tests/SimpleTestCases/EnumerableRepeat.cs
+++ b/Tests/SimpleTestCases/EnumerableRepeat.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+public static class Program {
+    public static void Main () {
+
+        foreach (var x in Enumerable.Repeat("x", 5))
+            Console.WriteLine(x);
+
+    }
+}

--- a/Tests/SimpleTests.csproj
+++ b/Tests/SimpleTests.csproj
@@ -311,6 +311,7 @@
     <None Include="SimpleTestCases\EnumInPlaceAdd.cs" />
     <None Include="SimpleTestCases\EnumerableStringMethod.cs" />
     <None Include="SimpleTestCases\EnumerableSkip.cs" />
+    <None Include="SimpleTestCases\EnumerableRepeat.cs" />
     <None Include="SimpleTestCases\UnboxBoolean.cs" />
     <None Include="SimpleTestCases\MathIntrinsics.cs" />
     <None Include="SimpleTestCases\StringSplitDefaultSeparators.cs" />


### PR DESCRIPTION
The external method Repeat<TResult>(TResult,int) was not implemented.
This commit introduces a test case and matching implementation returning
a JSIL AbstractEnumerable returning the element the appropriate number
of times.